### PR TITLE
feat: Add fetching methods (fetch_one, fetch_optional, fetch_all) and

### DIFF
--- a/crates/corrosion-orm-core/src/driver/connection.rs
+++ b/crates/corrosion-orm-core/src/driver/connection.rs
@@ -1,6 +1,7 @@
 use crate::{
     dialect::sql_dialect::SqlDialect, error::CorrosionOrmError, query::query_type::QueryContext,
 };
+use sqlx::FromRow;
 
 /// Trait for single database connection.
 #[trait_variant::make(Conn: Send)]
@@ -8,8 +9,30 @@ pub trait Connection: Sized + Sync + Send {
     /// Pings the connection to check if it is still valid.
     async fn ping_conn(&mut self) -> Result<(), CorrosionOrmError>;
     /// Executes a query and returns the number of affected rows.
+    ///
+    /// Returns the number of rows affected by the query.
     async fn execute_query(&mut self, ctx: &mut QueryContext) -> Result<u64, CorrosionOrmError>;
-
+    /// Fetches a single row from the result set.
+    ///
+    /// Returns a single row that implements the `FromRow` trait for the given row type.
+    async fn fetch_one<T: for<'r> FromRow<'r, sqlx::sqlite::SqliteRow> + Send + Unpin>(
+        &mut self,
+        ctx: &mut QueryContext,
+    ) -> Result<T, CorrosionOrmError>;
+    /// Fetches all rows from the result set.
+    ///
+    /// Returns a `Vec` of rows that implement the `FromRow` trait for the given row type.
+    async fn fetch_all<E: for<'r> FromRow<'r, sqlx::sqlite::SqliteRow> + Send + Unpin>(
+        &mut self,
+        ctx: &mut QueryContext,
+    ) -> Result<Vec<E>, CorrosionOrmError>;
+    /// Fetches a single row from the result set, if one exists.
+    ///
+    /// Returns `Ok(Some(row))` if a row is found, `Ok(None)` if no rows are found, or an error if one occurs.
+    async fn fetch_optional<E: for<'r> FromRow<'r, sqlx::sqlite::SqliteRow> + Send + Unpin>(
+        &mut self,
+        ctx: &mut QueryContext,
+    ) -> Result<Option<E>, CorrosionOrmError>;
     /// Begins a new transaction.
     async fn begin_transaction(&mut self) -> Result<(), CorrosionOrmError>;
     /// Commits the current transaction.

--- a/crates/corrosion-orm-core/src/driver/connection_pool.rs
+++ b/crates/corrosion-orm-core/src/driver/connection_pool.rs
@@ -1,3 +1,5 @@
+use sqlx::FromRow;
+
 use crate::{
     dialect::sql_dialect::SqlDialect,
     driver::{connection::Connection, executor::Executor, transaction::Transaction},
@@ -36,6 +38,26 @@ impl<P: ConnectionPool> Executor for ConnectionGuard<P> {
 
     fn get_dialect(&self) -> &dyn SqlDialect {
         self.conn.get_dialect()
+    }
+
+    async fn fetch_one<E: for<'r> FromRow<'r, sqlx::sqlite::SqliteRow> + Send + Unpin>(
+        &mut self,
+        ctx: &mut QueryContext,
+    ) -> Result<E, CorrosionOrmError> {
+        self.conn.fetch_one(ctx).await
+    }
+
+    async fn fetch_all<E: for<'r> FromRow<'r, sqlx::sqlite::SqliteRow> + Send + Unpin>(
+        &mut self,
+        ctx: &mut QueryContext,
+    ) -> Result<Vec<E>, CorrosionOrmError> {
+        self.conn.fetch_all(ctx).await
+    }
+    async fn fetch_optional<E: for<'r> FromRow<'r, sqlx::sqlite::SqliteRow> + Send + Unpin>(
+        &mut self,
+        ctx: &mut QueryContext,
+    ) -> Result<Option<E>, CorrosionOrmError> {
+        self.conn.fetch_optional(ctx).await
     }
 }
 /// A connection pool for managing database connections.

--- a/crates/corrosion-orm-core/src/driver/error.rs
+++ b/crates/corrosion-orm-core/src/driver/error.rs
@@ -13,4 +13,6 @@ pub enum DriverError {
     Sqlx(#[from] sqlx::Error),
     #[error("connection closed")]
     ConnectionClosed,
+    #[error("resource not found")]
+    NotFound,
 }

--- a/crates/corrosion-orm-core/src/driver/executor.rs
+++ b/crates/corrosion-orm-core/src/driver/executor.rs
@@ -1,3 +1,5 @@
+use sqlx::FromRow;
+
 use crate::{
     dialect::sql_dialect::SqlDialect, error::CorrosionOrmError, query::query_type::QueryContext,
 };
@@ -6,5 +8,18 @@ use crate::{
 #[trait_variant::make(Executor: Send)]
 pub trait LocalExecutor: Sized + Send + Sync {
     async fn execute_query(&mut self, ctx: &mut QueryContext) -> Result<u64, CorrosionOrmError>;
+    async fn fetch_one<E: for<'r> FromRow<'r, sqlx::sqlite::SqliteRow> + Send + Unpin>(
+        &mut self,
+        ctx: &mut QueryContext,
+    ) -> Result<E, CorrosionOrmError>;
+    async fn fetch_all<E: for<'r> FromRow<'r, sqlx::sqlite::SqliteRow> + Send + Unpin>(
+        &mut self,
+        ctx: &mut QueryContext,
+    ) -> Result<Vec<E>, CorrosionOrmError>;
+    async fn fetch_optional<E: for<'r> FromRow<'r, sqlx::sqlite::SqliteRow> + Send + Unpin>(
+        &mut self,
+        ctx: &mut QueryContext,
+    ) -> Result<Option<E>, CorrosionOrmError>;
+
     fn get_dialect(&self) -> &dyn SqlDialect;
 }

--- a/crates/corrosion-orm-core/src/driver/sqlite_driver/sqlite_connection.rs
+++ b/crates/corrosion-orm-core/src/driver/sqlite_driver/sqlite_connection.rs
@@ -1,5 +1,6 @@
 #[allow(clippy::disallowed_types)]
 use sqlx::Connection;
+use sqlx::FromRow;
 
 use crate::{
     dialect::{sql_dialect::SqlDialect, sqlite_dialect::sqlite::SqliteDialect},
@@ -28,6 +29,7 @@ impl crate::driver::connection::Conn for CorrosionSqliteConnection {
                 Value::Bool(b) => query.bind(b),
             }
         }
+
         log::info!("Executing SQL: {}", ctx.sql);
         let result = query
             .execute(self.inner.as_mut())
@@ -67,5 +69,71 @@ impl crate::driver::connection::Conn for CorrosionSqliteConnection {
 
     fn get_dialect(&self) -> &dyn SqlDialect {
         &SqliteDialect
+    }
+
+    async fn fetch_one<T: for<'r> FromRow<'r, sqlx::sqlite::SqliteRow> + Send + Unpin>(
+        &mut self,
+        ctx: &mut QueryContext,
+    ) -> Result<T, CorrosionOrmError> {
+        let mut query = sqlx::query_as::<_, T>(&ctx.sql);
+
+        for value in ctx.values.iter() {
+            query = match value {
+                Value::String(s) => query.bind(s),
+                Value::Int(i) => query.bind(i),
+                Value::Int64(i) => query.bind(i),
+                Value::Bool(b) => query.bind(b),
+            }
+        }
+
+        let result = query
+            .fetch_one(self.inner.as_mut())
+            .await
+            .map_err(DriverError::Sqlx)?;
+        Ok(result)
+    }
+
+    async fn fetch_all<E: for<'r> FromRow<'r, sqlx::sqlite::SqliteRow> + Send + Unpin>(
+        &mut self,
+        ctx: &mut QueryContext,
+    ) -> Result<Vec<E>, CorrosionOrmError> {
+        let mut query = sqlx::query_as::<_, E>(&ctx.sql);
+
+        for value in ctx.values.iter() {
+            query = match value {
+                Value::String(s) => query.bind(s),
+                Value::Int(i) => query.bind(i),
+                Value::Int64(i) => query.bind(i),
+                Value::Bool(b) => query.bind(b),
+            }
+        }
+
+        let result = query
+            .fetch_all(self.inner.as_mut())
+            .await
+            .map_err(DriverError::Sqlx)?;
+        Ok(result)
+    }
+
+    async fn fetch_optional<E: for<'r> FromRow<'r, sqlx::sqlite::SqliteRow> + Send + Unpin>(
+        &mut self,
+        ctx: &mut QueryContext,
+    ) -> Result<Option<E>, CorrosionOrmError> {
+        let mut query = sqlx::query_as::<_, E>(&ctx.sql);
+
+        for value in ctx.values.iter() {
+            query = match value {
+                Value::String(s) => query.bind(s),
+                Value::Int(i) => query.bind(i),
+                Value::Int64(i) => query.bind(i),
+                Value::Bool(b) => query.bind(b),
+            }
+        }
+
+        let result = query
+            .fetch_optional(self.inner.as_mut())
+            .await
+            .map_err(DriverError::Sqlx)?;
+        Ok(result)
     }
 }

--- a/crates/corrosion-orm-core/src/driver/transaction.rs
+++ b/crates/corrosion-orm-core/src/driver/transaction.rs
@@ -1,3 +1,5 @@
+use sqlx::FromRow;
+
 use crate::{
     dialect::sql_dialect::SqlDialect,
     driver::{
@@ -65,5 +67,39 @@ impl<P: ConnectionPool> Executor for Transaction<P> {
             .as_ref()
             .expect("Transaction connection closed")
             .get_dialect()
+    }
+
+    async fn fetch_one<E: for<'r> FromRow<'r, sqlx::sqlite::SqliteRow> + Send + Unpin>(
+        &mut self,
+        ctx: &mut QueryContext,
+    ) -> Result<E, CorrosionOrmError> {
+        match self.conn.as_mut() {
+            Some(conn) => conn.fetch_one(ctx).await,
+            None => Err(CorrosionOrmError::DriverError(
+                DriverError::ConnectionClosed,
+            )),
+        }
+    }
+    async fn fetch_all<E: for<'r> FromRow<'r, sqlx::sqlite::SqliteRow> + Send + Unpin>(
+        &mut self,
+        ctx: &mut QueryContext,
+    ) -> Result<Vec<E>, CorrosionOrmError> {
+        match self.conn.as_mut() {
+            Some(conn) => conn.fetch_all(ctx).await,
+            None => Err(CorrosionOrmError::DriverError(
+                DriverError::ConnectionClosed,
+            )),
+        }
+    }
+    async fn fetch_optional<E: for<'r> FromRow<'r, sqlx::sqlite::SqliteRow> + Send + Unpin>(
+        &mut self,
+        ctx: &mut QueryContext,
+    ) -> Result<Option<E>, CorrosionOrmError> {
+        match self.conn.as_mut() {
+            Some(conn) => conn.fetch_optional(ctx).await,
+            None => Err(CorrosionOrmError::DriverError(
+                DriverError::ConnectionClosed,
+            )),
+        }
     }
 }

--- a/crates/corrosion-orm-macros/src/generator/repository_generate.rs
+++ b/crates/corrosion-orm-macros/src/generator/repository_generate.rs
@@ -58,14 +58,42 @@ pub(crate) fn generate_repository(table: &TableData) -> proc_macro2::TokenStream
                     update_query.to_sql(&mut ctx, db.get_dialect());
                     db.execute_query(&mut ctx).await?;
                 }
-                Ok(self.clone())
-            }
+                let mut fetch_ctx = QueryContext::new();
+                let fetch_query = corrosion_orm_core::query::select::Select::from(&schema)
+                    .where_clause(WhereClause::eq(&schema.primary_key.name, self.#pk_ident.clone()));
+                fetch_query.to_sql(&mut fetch_ctx, db.get_dialect());
+                let saved = db.fetch_optional::<Self>(&mut fetch_ctx).await?;
 
+                saved.ok_or(corrosion_orm_core::driver::error::DriverError::NotFound.into())
+            }
             async fn get_all(db: &mut Db) -> Result<Vec<Self>, corrosion_orm_core::error::CorrosionOrmError> {
-                todo!();
+                use corrosion_orm_core::query::to_sql::ToSql;
+                use corrosion_orm_core::schema::table::TableSchema;
+                use corrosion_orm_core::query::where_clause::WhereClause;
+                use corrosion_orm_core::query::query_type::QueryContext;
+                let mut ctx = QueryContext::new();
+                let schema = Self::get_schema();
+                let query = corrosion_orm_core::query::select::Select::from(&schema);
+                query.to_sql(&mut ctx, db.get_dialect());
+                let results = db.fetch_all::<Self>(&mut ctx).await?;
+                Ok(results)
             }
             async fn get_by_id(id: Self::PrimaryKey, db: &mut Db) -> Result<Self, corrosion_orm_core::error::CorrosionOrmError> {
-                todo!()
+                use corrosion_orm_core::query::to_sql::ToSql;
+                use corrosion_orm_core::schema::table::TableSchema;
+                use corrosion_orm_core::query::where_clause::WhereClause;
+                use corrosion_orm_core::query::query_type::QueryContext;
+                let mut ctx = QueryContext::new();
+                let schema = Self::get_schema();
+                let query = corrosion_orm_core::query::select::Select::from(&schema)
+                    .where_clause(WhereClause::eq(&schema.primary_key.name, id.clone()));
+                query.to_sql(&mut ctx, db.get_dialect());
+                let result = db.fetch_optional::<Self>(&mut ctx).await?;
+                if let Some(result) = result {
+                    Ok(result)
+                } else {
+                    Err(corrosion_orm_core::driver::error::DriverError::NotFound.into())
+                }
             }
             async fn delete(self, db: &mut Db) -> Result<(), corrosion_orm_core::error::CorrosionOrmError> {
                 use corrosion_orm_core::query::to_sql::ToSql;


### PR DESCRIPTION

This pull request adds support for fetching rows from the database using the `sqlx::FromRow` trait, significantly improving the ergonomics and capabilities of the ORM's query API. It introduces new fetch methods to the connection, executor, transaction, and connection pool layers, and updates the repository macro to leverage these new capabilities for more complete and robust CRUD operations.

**New fetch methods and trait integration:**

- Added `fetch_one`, `fetch_all`, and `fetch_optional` methods to the `Connection`, `Executor`, and related traits, all using the `sqlx::FromRow` trait for type-safe row mapping. [[1]](diffhunk://#diff-bfb390acbf05f59011cf582e5ba472a5e4e4c7dbc815652ffdba95eed93a9a91R4-R35) [[2]](diffhunk://#diff-6b7c36885cbe98e884cfd2d4a69faefbb95fe36424b71c4062bceaf3b90137d3R11-R23) [[3]](diffhunk://#diff-c86195db3f0b0a3d0ce6678751536203b78849cf213ba59dc2c96d222ce1c6bdR73-R138) [[4]](diffhunk://#diff-d13d0af5916746462470b6697834c5a63bdbd80ab9f53968e42acf6c04201acaR42-R61) [[5]](diffhunk://#diff-78b4e2112a121f69f19f5519f1982682a4f3cc113b7468f0c513d5ad2291b6a0R71-R104)
- Implemented these methods for SQLite connections, connection pools, and transactions, ensuring consistent behavior and error handling across all database access layers. [[1]](diffhunk://#diff-c86195db3f0b0a3d0ce6678751536203b78849cf213ba59dc2c96d222ce1c6bdR73-R138) [[2]](diffhunk://#diff-d13d0af5916746462470b6697834c5a63bdbd80ab9f53968e42acf6c04201acaR42-R61) [[3]](diffhunk://#diff-78b4e2112a121f69f19f5519f1982682a4f3cc113b7468f0c513d5ad2291b6a0R71-R104)

**Repository macro and CRUD improvements:**

- Updated the repository macro to use the new fetch methods for `save`, `get_all`, and `get_by_id`, providing complete implementations for these operations and returning more meaningful errors when resources are not found.

**Error handling:**

- Added a new `NotFound` variant to `DriverError` to standardize error reporting when requested resources are missing.

**Internal refactoring and imports:**

- Added necessary imports for `sqlx::FromRow` in relevant modules to support the new fetch functionality. [[1]](diffhunk://#diff-d13d0af5916746462470b6697834c5a63bdbd80ab9f53968e42acf6c04201acaR1-R2) [[2]](diffhunk://#diff-6b7c36885cbe98e884cfd2d4a69faefbb95fe36424b71c4062bceaf3b90137d3R1-R2) [[3]](diffhunk://#diff-78b4e2112a121f69f19f5519f1982682a4f3cc113b7468f0c513d5ad2291b6a0R1-R2) [[4]](diffhunk://#diff-c86195db3f0b0a3d0ce6678751536203b78849cf213ba59dc2c96d222ce1c6bdR3)

These changes make the ORM more convenient and robust for developers, enabling type-safe and idiomatic data retrieval throughout the codebase.