### PR TITLE
feat: Logging in abstraction layer conditional on "log" feature

### DIFF
--- a/crates/corrosion-orm-core/Cargo.toml
+++ b/crates/corrosion-orm-core/Cargo.toml
@@ -5,12 +5,13 @@ edition = "2024"
 [features]
 default = ["sqlite"]
 sqlite = ["dep:sqlx", "sqlx/sqlite", "sqlx/runtime-tokio"]
+log = ["dep:log"]
 test-utils = []
 [dependencies]
 chrono  = { workspace = true }
 deluxe  = { workspace = true }
 thiserror = { workspace = true }
 sqlx = { version = "0.8.6", optional = true, default-features = false }
-log = { workspace = true }
+log = { workspace = true, optional = true }
 tokio = { workspace = true }
 trait-variant = "0.1.2"

--- a/crates/corrosion-orm-core/src/driver/connection_pool.rs
+++ b/crates/corrosion-orm-core/src/driver/connection_pool.rs
@@ -34,11 +34,11 @@ impl<P: ConnectionPool> DerefMut for ConnectionGuard<P> {
 impl<P: ConnectionPool> Executor for ConnectionGuard<P> {
     async fn execute_query(&mut self, ctx: &mut QueryContext) -> Result<u64, CorrosionOrmError> {
         #[cfg(feature = "log")]
-        log::info!(
-            "Executing SQL: {}",
-            ctx.to_debug_sql(self.conn.get_dialect())
-        );
+        let sql = ctx.to_debug_sql(self.conn.get_dialect());
+        #[cfg(feature = "log")]
+        log::info!("Executing SQL: {}", sql);
         let result = self.conn.execute_query(ctx).await;
+
         match &result {
             Ok(_value) => {
                 #[cfg(feature = "log")]
@@ -46,10 +46,7 @@ impl<P: ConnectionPool> Executor for ConnectionGuard<P> {
             }
             Err(_err) => {
                 #[cfg(feature = "log")]
-                log::warn!(
-                    "Failed to execute SQL: {}",
-                    ctx.to_debug_sql(self.conn.get_dialect())
-                );
+                log::warn!("Failed to execute SQL: {}. Error: {:?}", sql, _err);
             }
         }
         result
@@ -69,17 +66,16 @@ impl<P: ConnectionPool> Executor for ConnectionGuard<P> {
             ctx.to_debug_sql(self.conn.get_dialect())
         );
         let result = self.conn.fetch_one(ctx).await;
+        #[cfg(feature = "log")]
+        let sql = ctx.to_debug_sql(self.conn.get_dialect());
         match &result {
             Ok(_value) => {
                 #[cfg(feature = "log")]
-                log::info!("Fetched one: {}", ctx.to_debug_sql(self.conn.get_dialect()));
+                log::info!("Fetched one: {}", sql);
             }
             Err(_err) => {
                 #[cfg(feature = "log")]
-                log::warn!(
-                    "Failed to fetch one: {}",
-                    ctx.to_debug_sql(self.conn.get_dialect())
-                );
+                log::warn!("Failed to fetch one: {}. Error: {:?}", sql, _err);
             }
         }
         result
@@ -95,17 +91,16 @@ impl<P: ConnectionPool> Executor for ConnectionGuard<P> {
             ctx.to_debug_sql(self.conn.get_dialect())
         );
         let result = self.conn.fetch_all(ctx).await;
+        #[cfg(feature = "log")]
+        let sql = ctx.to_debug_sql(self.conn.get_dialect());
         match &result {
             Ok(_value) => {
                 #[cfg(feature = "log")]
-                log::info!("Fetched all: {}", ctx.to_debug_sql(self.conn.get_dialect()));
+                log::info!("Fetched all: {}", sql);
             }
             Err(_err) => {
                 #[cfg(feature = "log")]
-                log::warn!(
-                    "Failed to fetch all: {}",
-                    ctx.to_debug_sql(self.conn.get_dialect())
-                );
+                log::warn!("Failed to fetch all: {}. Error: {:?}", sql, _err);
             }
         }
         result
@@ -115,25 +110,18 @@ impl<P: ConnectionPool> Executor for ConnectionGuard<P> {
         ctx: &mut QueryContext,
     ) -> Result<Option<E>, CorrosionOrmError> {
         #[cfg(feature = "log")]
-        log::info!(
-            "Fetching optional: {}",
-            ctx.to_debug_sql(self.conn.get_dialect())
-        );
+        let sql = ctx.to_debug_sql(self.conn.get_dialect());
+        #[cfg(feature = "log")]
+        log::info!("Fetching optional: {}", sql);
         let result = self.conn.fetch_optional(ctx).await;
         match &result {
             Ok(_value) => {
                 #[cfg(feature = "log")]
-                log::info!(
-                    "Fetched optional: {}",
-                    ctx.to_debug_sql(self.conn.get_dialect())
-                );
+                log::info!("Fetched optional: {}", sql);
             }
             Err(_err) => {
                 #[cfg(feature = "log")]
-                log::warn!(
-                    "Failed to fetch optional: {}",
-                    ctx.to_debug_sql(self.conn.get_dialect())
-                );
+                log::warn!("Failed to fetch optional: {}. Error: {:?}", sql, _err);
             }
         }
         result

--- a/crates/corrosion-orm-core/src/driver/connection_pool.rs
+++ b/crates/corrosion-orm-core/src/driver/connection_pool.rs
@@ -2,7 +2,7 @@ use sqlx::FromRow;
 
 use crate::{
     dialect::sql_dialect::SqlDialect,
-    driver::{connection::Connection, executor::Executor, transaction::Transaction},
+    driver::{connection::Conn, executor::Executor, transaction::Transaction},
     error::CorrosionOrmError,
     query::query_type::QueryContext,
 };
@@ -33,7 +33,26 @@ impl<P: ConnectionPool> DerefMut for ConnectionGuard<P> {
 }
 impl<P: ConnectionPool> Executor for ConnectionGuard<P> {
     async fn execute_query(&mut self, ctx: &mut QueryContext) -> Result<u64, CorrosionOrmError> {
-        self.conn.execute_query(ctx).await
+        #[cfg(feature = "log")]
+        log::info!(
+            "Executing SQL: {}",
+            ctx.to_debug_sql(self.conn.get_dialect())
+        );
+        let result = self.conn.execute_query(ctx).await;
+        match &result {
+            Ok(_value) => {
+                #[cfg(feature = "log")]
+                log::info!("Executed SQL Rows affected: {}", _value);
+            }
+            Err(_err) => {
+                #[cfg(feature = "log")]
+                log::warn!(
+                    "Failed to execute SQL: {}",
+                    ctx.to_debug_sql(self.conn.get_dialect())
+                );
+            }
+        }
+        result
     }
 
     fn get_dialect(&self) -> &dyn SqlDialect {
@@ -44,20 +63,80 @@ impl<P: ConnectionPool> Executor for ConnectionGuard<P> {
         &mut self,
         ctx: &mut QueryContext,
     ) -> Result<E, CorrosionOrmError> {
-        self.conn.fetch_one(ctx).await
+        #[cfg(feature = "log")]
+        log::info!(
+            "Executing SQL: {}",
+            ctx.to_debug_sql(self.conn.get_dialect())
+        );
+        let result = self.conn.fetch_one(ctx).await;
+        match &result {
+            Ok(_value) => {
+                #[cfg(feature = "log")]
+                log::info!("Fetched one: {}", ctx.to_debug_sql(self.conn.get_dialect()));
+            }
+            Err(_err) => {
+                #[cfg(feature = "log")]
+                log::warn!(
+                    "Failed to fetch one: {}",
+                    ctx.to_debug_sql(self.conn.get_dialect())
+                );
+            }
+        }
+        result
     }
 
     async fn fetch_all<E: for<'r> FromRow<'r, sqlx::sqlite::SqliteRow> + Send + Unpin>(
         &mut self,
         ctx: &mut QueryContext,
     ) -> Result<Vec<E>, CorrosionOrmError> {
-        self.conn.fetch_all(ctx).await
+        #[cfg(feature = "log")]
+        log::info!(
+            "Fetching all: {}",
+            ctx.to_debug_sql(self.conn.get_dialect())
+        );
+        let result = self.conn.fetch_all(ctx).await;
+        match &result {
+            Ok(_value) => {
+                #[cfg(feature = "log")]
+                log::info!("Fetched all: {}", ctx.to_debug_sql(self.conn.get_dialect()));
+            }
+            Err(_err) => {
+                #[cfg(feature = "log")]
+                log::warn!(
+                    "Failed to fetch all: {}",
+                    ctx.to_debug_sql(self.conn.get_dialect())
+                );
+            }
+        }
+        result
     }
     async fn fetch_optional<E: for<'r> FromRow<'r, sqlx::sqlite::SqliteRow> + Send + Unpin>(
         &mut self,
         ctx: &mut QueryContext,
     ) -> Result<Option<E>, CorrosionOrmError> {
-        self.conn.fetch_optional(ctx).await
+        #[cfg(feature = "log")]
+        log::info!(
+            "Fetching optional: {}",
+            ctx.to_debug_sql(self.conn.get_dialect())
+        );
+        let result = self.conn.fetch_optional(ctx).await;
+        match &result {
+            Ok(_value) => {
+                #[cfg(feature = "log")]
+                log::info!(
+                    "Fetched optional: {}",
+                    ctx.to_debug_sql(self.conn.get_dialect())
+                );
+            }
+            Err(_err) => {
+                #[cfg(feature = "log")]
+                log::warn!(
+                    "Failed to fetch optional: {}",
+                    ctx.to_debug_sql(self.conn.get_dialect())
+                );
+            }
+        }
+        result
     }
 }
 /// A connection pool for managing database connections.

--- a/crates/corrosion-orm-core/src/driver/sqlite_driver/sqlite_connection.rs
+++ b/crates/corrosion-orm-core/src/driver/sqlite_driver/sqlite_connection.rs
@@ -30,7 +30,6 @@ impl crate::driver::connection::Conn for CorrosionSqliteConnection {
             }
         }
 
-        log::info!("Executing SQL: {}", ctx.sql);
         let result = query
             .execute(self.inner.as_mut())
             .await

--- a/crates/corrosion-orm-core/src/query/query_type.rs
+++ b/crates/corrosion-orm-core/src/query/query_type.rs
@@ -63,6 +63,24 @@ impl QueryContext {
             placeholder_count: 0,
         }
     }
+    #[cfg(feature = "log")]
+    pub fn to_debug_sql(&self, dialect: &dyn SqlDialect) -> String {
+        let mut sql = self.sql.clone();
+        for (idx, value) in self.values.iter().enumerate().rev() {
+            let placeholder = dialect.bind_param(&(idx + 1));
+
+            if let Some(pos) = sql.rfind(&placeholder) {
+                let value_str = match value {
+                    Value::String(s) => format!("'{}'", s.replace('\'', "''")),
+                    Value::Int(i) => i.to_string(),
+                    Value::Int64(i) => i.to_string(),
+                    Value::Bool(b) => if *b { "1" } else { "0" }.to_string(),
+                };
+                sql.replace_range(pos..pos + placeholder.len(), &value_str);
+            }
+        }
+        sql
+    }
     /// Pushes a bind parameter to the query context, updating the SQL string and values vector.
     ///
     /// # Arguments

--- a/crates/corrosion-orm-core/src/query/query_type.rs
+++ b/crates/corrosion-orm-core/src/query/query_type.rs
@@ -66,9 +66,9 @@ impl QueryContext {
     #[cfg(feature = "log")]
     pub fn to_debug_sql(&self, dialect: &dyn SqlDialect) -> String {
         let mut sql = self.sql.clone();
-        for (idx, value) in self.values.iter().enumerate().rev() {
-            let placeholder = dialect.bind_param(&(idx + 1));
-
+        for idx in (1..=self.values.len()).rev() {
+            let value = &self.values[idx - 1];
+            let placeholder = dialect.bind_param(&idx);
             if let Some(pos) = sql.rfind(&placeholder) {
                 let value_str = match value {
                     Value::String(s) => format!("'{}'", s.replace('\'', "''")),

--- a/crates/corrosion-orm-test/Cargo.toml
+++ b/crates/corrosion-orm-test/Cargo.toml
@@ -3,10 +3,10 @@ name = "corrosion-orm-test"
 version = "0.1.0"
 edition = "2024"
 [dependencies]
-corrosion-orm-core = {path="../corrosion-orm-core", features = ["sqlite","test-utils"]}
+corrosion-orm-core = {path="../corrosion-orm-core", features = ["sqlite","test-utils","log"]}
 corrosion-orm-macros = {path="../corrosion-orm-macros"}
 insta = { workspace = true }
 tokio = { workspace = true }
 sqlx = {version = "0.8.6", features = ["runtime-tokio","sqlite"]}
+env_logger = "0.11"
 log = { workspace = true }
-env_logger = "0.11.10"

--- a/crates/corrosion-orm-test/src/test_entities.rs
+++ b/crates/corrosion-orm-test/src/test_entities.rs
@@ -35,7 +35,11 @@ impl User {
 pub(crate) async fn init_sqlite() -> SqliteDriver {
     use corrosion_orm_core::SqliteDriver;
     use corrosion_orm_core::prelude::*;
-    let _ = env_logger::builder().is_test(true).try_init();
+
+    let _ = env_logger::builder()
+        .is_test(true)
+        .filter_level(log::LevelFilter::Info)
+        .try_init();
 
     let config = SqliteConfigBuilder::new()
         .url(String::from(":memory:"))


### PR DESCRIPTION
Closes #2 
This pull request adds optional logging capabilities to the core ORM library, enabling detailed SQL execution tracing when the `log` feature is enabled. Logging is now handled in the connection pool layer rather than in individual driver implementations, and a utility method has been introduced to render SQL queries with their parameters for clearer log output.

Logging enhancements:

* Added a new optional `log` feature to `corrosion-orm-core`, making the `log` dependency optional and allowing consumers to opt-in to SQL logging.
* Implemented detailed logging for SQL execution, fetch, and error cases in the `ConnectionGuard` implementation of the `Executor` trait, using the new `to_debug_sql` method to display SQL with parameters. [[1]](diffhunk://#diff-d13d0af5916746462470b6697834c5a63bdbd80ab9f53968e42acf6c04201acaL36-R55) [[2]](diffhunk://#diff-d13d0af5916746462470b6697834c5a63bdbd80ab9f53968e42acf6c04201acaL47-R139)
* Introduced the `to_debug_sql` method on `QueryContext` to generate SQL statements with parameter values interpolated, improving the clarity of logged queries.
* Moved SQL logging out of the `CorrosionSqliteConnection` implementation, centralizing it in the connection pool logic.

Test and dependency updates:

* Enabled the `log` feature by default in the test crate and configured `env_logger` to use the `Info` level for better visibility of log output during tests. [[1]](diffhunk://#diff-dc982f0fdfb7fa23e0b317d60da877b2fa25bde16b5ff7c5cd3756e18b26618aL6-L12) [[2]](diffhunk://#diff-b198802f3dc581c65b750e707570a3705e2ecb2285f1421ef200d0c7401f3031L38-R42)