### PR TITLE
Test/repository

### DIFF
--- a/crates/corrosion-orm-core/src/lib.rs
+++ b/crates/corrosion-orm-core/src/lib.rs
@@ -25,6 +25,7 @@ pub mod prelude {
     pub use crate::driver::executor::Executor;
     pub use crate::driver::sql_driver::SqlDriver;
     pub use crate::driver::transaction::Transaction;
+    pub use crate::error::CorrosionOrmError;
     pub use crate::model::repository::Repo;
     pub use crate::query::*;
     pub use crate::query::{

--- a/crates/corrosion-orm-macros/src/generator/repository_generate.rs
+++ b/crates/corrosion-orm-macros/src/generator/repository_generate.rs
@@ -36,17 +36,17 @@ pub(crate) fn generate_repository(table: &TableData) -> proc_macro2::TokenStream
 
                 let schema = Self::get_schema();
 
-                let is_new_query = corrosion_orm_core::query::select::Select::from(&schema)
+                let check_query = corrosion_orm_core::query::select::Select::from(&schema)
                     .where_clause(
                         WhereClause::eq(&schema.primary_key.name, self.#pk_ident.clone()),
                 );
 
                 let mut ctx_control = corrosion_orm_core::query::query_type::QueryContext::new();
-                is_new_query.to_sql(&mut ctx_control, db.get_dialect());
-                let is_new = db.execute_query(&mut ctx_control).await?;
+                check_query.to_sql(&mut ctx_control, db.get_dialect());
+                let existing = db.fetch_optional::<Self>(&mut ctx_control).await?;
 
                 let mut ctx = QueryContext::new();
-                if is_new == 0 {
+                if existing.is_none() {
                     let mut insert_query = corrosion_orm_core::query::insert::Insert::from(&schema)
                         .values(self.get_values_from_self());
                     insert_query.to_sql(&mut ctx, db.get_dialect());

--- a/crates/corrosion-orm-test/src/repository_test/delete_test.rs
+++ b/crates/corrosion-orm-test/src/repository_test/delete_test.rs
@@ -10,5 +10,66 @@ mod tests {
         let mut conn = driver.acquire_conn().await.unwrap();
         user.save(&mut conn).await.unwrap();
         user.delete(&mut conn).await.unwrap();
+        assert!(User::get_by_id(1, &mut conn).await.is_err());
+    }
+    #[tokio::test]
+    async fn test_delete_not_found() {
+        let user = User::example();
+        let driver = init_sqlite().await;
+        let mut conn = driver.acquire_conn().await.unwrap();
+        user.delete(&mut conn).await.unwrap();
+    }
+    #[tokio::test]
+    async fn test_delete_verifies_removed() {
+        let driver = init_sqlite().await;
+        let user = User::example();
+
+        let mut conn = driver.acquire_conn().await.unwrap();
+        user.save(&mut conn).await.unwrap();
+        drop(conn);
+
+        let mut conn = driver.acquire_conn().await.unwrap();
+        user.delete(&mut conn).await.unwrap();
+        drop(conn);
+
+        let mut conn = driver.acquire_conn().await.unwrap();
+        let result = User::get_by_id(1, &mut conn).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_delete_with_transaction() {
+        let user = User::example();
+        let driver = init_sqlite().await;
+
+        let mut tx = driver.transaction().await.unwrap();
+        user.save(&mut tx).await.unwrap();
+
+        let retrieved_user = User::get_by_id(1, &mut tx).await.unwrap();
+        assert_eq!(retrieved_user.id, 1);
+
+        retrieved_user.delete(&mut tx).await.unwrap();
+        tx.commit().await.unwrap();
+
+        let mut conn = driver.acquire_conn().await.unwrap();
+        assert!(User::get_by_id(1, &mut conn).await.is_err());
+    }
+    #[tokio::test]
+    async fn test_delete_with_transaction_not_found() {
+        let driver = init_sqlite().await;
+        let mut tx = driver.transaction().await.unwrap();
+        let res = User::get_by_id(1, &mut tx).await;
+        assert!(res.is_err());
+        tx.commit().await.unwrap();
+    }
+    #[tokio::test]
+    async fn test_delete_with_transaction_rollback() {
+        let user = User::example();
+        let driver = init_sqlite().await;
+        let mut tx = driver.transaction().await.unwrap();
+        user.save(&mut tx).await.unwrap();
+        tx.rollback().await.unwrap();
+        let mut conn = driver.acquire_conn().await.unwrap();
+        assert!(User::get_by_id(1, &mut conn).await.is_err());
     }
 }

--- a/crates/corrosion-orm-test/src/repository_test/get_test.rs
+++ b/crates/corrosion-orm-test/src/repository_test/get_test.rs
@@ -1,0 +1,120 @@
+#[cfg(test)]
+mod tests {
+    use crate::{init_sqlite, test_entities::User};
+    use corrosion_orm_core::prelude::*;
+
+    #[tokio::test]
+    async fn test_get_by_id() {
+        let driver = init_sqlite().await;
+
+        let user = User::example();
+        let mut conn = driver.acquire_conn().await.unwrap();
+        user.save(&mut conn).await.unwrap();
+        let db_user = User::get_by_id(user.id, &mut conn).await.unwrap();
+        assert_eq!(user.id, db_user.id);
+    }
+    #[tokio::test]
+    async fn test_get_by_id_not_found() {
+        let driver = init_sqlite().await;
+        let mut conn = driver.acquire_conn().await.unwrap();
+        let result = User::get_by_id(999, &mut conn).await;
+        assert!(result.is_err());
+    }
+    #[tokio::test]
+    async fn test_get_all() {
+        let driver = init_sqlite().await;
+        let mut conn = driver.acquire_conn().await.unwrap();
+        let user = User::example();
+        user.save(&mut conn).await.unwrap();
+        let users = User::get_all(&mut conn).await.unwrap();
+        assert_eq!(1, users.len());
+    }
+    #[tokio::test]
+    async fn test_get_all_empty() {
+        let driver = init_sqlite().await;
+        let mut conn = driver.acquire_conn().await.unwrap();
+        let users = User::get_all(&mut conn).await.unwrap();
+        assert!(users.is_empty());
+    }
+    #[tokio::test]
+    async fn test_get_all_multiple() {
+        let driver = init_sqlite().await;
+        let mut conn = driver.acquire_conn().await.unwrap();
+        for i in 0..10 {
+            let user = User {
+                id: i,
+                name: format!("user{}", i),
+            };
+            user.save(&mut conn).await.unwrap();
+        }
+        let users = User::get_all(&mut conn).await.unwrap();
+        assert_eq!(10, users.len());
+        for (i, user) in users.iter().enumerate() {
+            assert_eq!(i, user.id as usize);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_by_id_with_transaction() {
+        let user = User::example();
+        let driver = init_sqlite().await;
+
+        let mut tx = driver.transaction().await.unwrap();
+        user.save(&mut tx).await.unwrap();
+
+        let retrieved_user = User::get_by_id(user.id, &mut tx).await.unwrap();
+        assert_eq!(retrieved_user.id, user.id);
+
+        tx.commit().await.unwrap();
+
+        let mut conn = driver.acquire_conn().await.unwrap();
+        let db_user = User::get_by_id(user.id, &mut conn).await.unwrap();
+        assert_eq!(user.id, db_user.id);
+    }
+
+    #[tokio::test]
+    async fn test_get_all_with_transaction() {
+        let driver = init_sqlite().await;
+
+        let mut tx = driver.transaction().await.unwrap();
+        for i in 0..5 {
+            let user = User {
+                id: i,
+                name: format!("user{}", i),
+            };
+            user.save(&mut tx).await.unwrap();
+        }
+
+        let users = User::get_all(&mut tx).await.unwrap();
+        assert_eq!(5, users.len());
+
+        tx.commit().await.unwrap();
+
+        let mut conn = driver.acquire_conn().await.unwrap();
+        let db_users = User::get_all(&mut conn).await.unwrap();
+        assert_eq!(5, db_users.len());
+    }
+
+    #[tokio::test]
+    async fn test_get_with_transaction_not_found() {
+        let driver = init_sqlite().await;
+        let mut tx = driver.transaction().await.unwrap();
+        let result = User::get_by_id(999, &mut tx).await;
+        assert!(result.is_err());
+        tx.commit().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_get_with_transaction_after_rollback() {
+        let user = User::example();
+        let driver = init_sqlite().await;
+
+        let mut tx = driver.transaction().await.unwrap();
+        user.save(&mut tx).await.unwrap();
+        tx.rollback().await.unwrap();
+
+        let mut conn = driver.acquire_conn().await.unwrap();
+        let result = User::get_by_id(user.id, &mut conn).await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/corrosion-orm-test/src/repository_test/mod.rs
+++ b/crates/corrosion-orm-test/src/repository_test/mod.rs
@@ -1,2 +1,3 @@
 mod delete_test;
+mod get_test;
 mod save_test;

--- a/crates/corrosion-orm-test/src/repository_test/save_test.rs
+++ b/crates/corrosion-orm-test/src/repository_test/save_test.rs
@@ -11,4 +11,116 @@ mod tests {
         user.save(&mut conn).await.unwrap();
         let _saved_user = user.save(&mut conn).await.unwrap();
     }
+    #[tokio::test]
+    async fn test_save_verifies_saved() {
+        let user = User::example();
+        let driver = init_sqlite().await;
+        let mut conn = driver.acquire_conn().await.unwrap();
+        user.save(&mut conn).await.unwrap();
+        drop(conn);
+        let mut conn = driver.acquire_conn().await.unwrap();
+        let result = User::get_by_id(1, &mut conn).await;
+        assert!(result.is_ok());
+    }
+    #[tokio::test]
+    async fn test_save_update() {
+        let user = User::example();
+        let driver = init_sqlite().await;
+        let mut conn = driver.acquire_conn().await.unwrap();
+        user.save(&mut conn).await.unwrap();
+        drop(conn);
+        let mut conn = driver.acquire_conn().await.unwrap();
+        let mut updated_user = User::example();
+        updated_user.name = String::from("Alice");
+        updated_user.save(&mut conn).await.unwrap();
+        let result = User::get_by_id(1, &mut conn).await.unwrap();
+        assert_eq!(result.name, "Alice")
+    }
+    #[tokio::test]
+    async fn test_save_with_transaction_commit() {
+        let user = User::example();
+        let driver = init_sqlite().await;
+
+        let mut tx = driver.transaction().await.unwrap();
+        user.save(&mut tx).await.unwrap();
+        tx.commit().await.unwrap();
+
+        let mut conn = driver.acquire_conn().await.unwrap();
+        let result = User::get_by_id(1, &mut conn).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().id, 1);
+    }
+
+    #[tokio::test]
+    async fn test_save_with_transaction_rollback() {
+        let user = User::example();
+        let driver = init_sqlite().await;
+
+        let mut tx = driver.transaction().await.unwrap();
+        user.save(&mut tx).await.unwrap();
+        tx.rollback().await.unwrap();
+
+        let mut conn = driver.acquire_conn().await.unwrap();
+        let result = User::get_by_id(1, &mut conn).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_save_update_with_transaction_commit() {
+        let user = User::example();
+        let driver = init_sqlite().await;
+
+        let mut conn = driver.acquire_conn().await.unwrap();
+        user.save(&mut conn).await.unwrap();
+        drop(conn);
+
+        let mut tx = driver.transaction().await.unwrap();
+        let mut updated_user = User::get_by_id(1, &mut tx).await.unwrap();
+        updated_user.name = String::from("Alice");
+        updated_user.save(&mut tx).await.unwrap();
+        tx.commit().await.unwrap();
+
+        let mut conn = driver.acquire_conn().await.unwrap();
+        let result = User::get_by_id(1, &mut conn).await.unwrap();
+        assert_eq!(result.name, "Alice");
+    }
+
+    #[tokio::test]
+    async fn test_save_multiple_with_transaction_commit() {
+        let driver = init_sqlite().await;
+
+        let mut tx = driver.transaction().await.unwrap();
+
+        let user1 = User {
+            id: 1,
+            name: String::from("Alice"),
+        };
+        user1.save(&mut tx).await.unwrap();
+
+        let user2 = User {
+            id: 2,
+            name: String::from("Bob"),
+        };
+        user2.save(&mut tx).await.unwrap();
+
+        let user3 = User {
+            id: 3,
+            name: String::from("Charlie"),
+        };
+        user3.save(&mut tx).await.unwrap();
+
+        tx.commit().await.unwrap();
+
+        let mut conn = driver.acquire_conn().await.unwrap();
+        let result1 = User::get_by_id(1, &mut conn).await;
+        let result2 = User::get_by_id(2, &mut conn).await;
+        let result3 = User::get_by_id(3, &mut conn).await;
+
+        assert!(result1.is_ok());
+        assert!(result2.is_ok());
+        assert!(result3.is_ok());
+        assert_eq!(result1.unwrap().name, "Alice");
+        assert_eq!(result2.unwrap().name, "Bob");
+        assert_eq!(result3.unwrap().name, "Charlie");
+    }
 }

--- a/crates/corrosion-orm-test/src/test_entities.rs
+++ b/crates/corrosion-orm-test/src/test_entities.rs
@@ -38,7 +38,8 @@ pub(crate) async fn init_sqlite() -> SqliteDriver {
 
     let _ = env_logger::builder()
         .is_test(true)
-        .filter_level(log::LevelFilter::Info)
+        .filter_level(log::LevelFilter::max())
+        .filter_module("sqlx", log::LevelFilter::Off)
         .try_init();
 
     let config = SqliteConfigBuilder::new()


### PR DESCRIPTION
This pull request significantly improves the test coverage and correctness of the repository layer in the Corrosion ORM project. It introduces comprehensive tests for CRUD operations (get, save, delete) including transactional scenarios, and refines the logic for determining record existence in the repository generator. Additionally, it enhances logging configuration for cleaner test output and expands the public prelude.

**Repository CRUD operation improvements and test coverage:**

* Added extensive tests for `get_by_id`, `get_all`, and their transactional variants, ensuring correct behavior for found, not found, empty, and rollback scenarios (`get_test.rs`, `mod.rs`) [[1]](diffhunk://#diff-3c444abe48c3bda66bc16936946e27113dc1aa02cc437664267734e039042d2fR1-R120) [[2]](diffhunk://#diff-e96a1587b0f40a5ae8f85d31344bcea633e0948075e300a5743fe61e0d59cb76R2).
* Added comprehensive tests for `save` operations, including verification after save, update, transactional commit/rollback, and saving multiple records in a single transaction (`save_test.rs`).
* Expanded delete operation tests to cover not found, verification after delete, and transactional commit/rollback scenarios (`delete_test.rs`).

**Repository logic and ergonomics:**

* Updated repository code generation to use `fetch_optional` for existence checks instead of relying on row count, improving correctness and clarity (`repository_generate.rs`).
* Re-exported `CorrosionOrmError` in the public prelude for easier error handling in downstream code (`lib.rs`).

**Developer experience:**

* Improved test logging configuration to suppress verbose SQLx logs and show only relevant output (`test_entities.rs`).