### PR TITLE
Test/repository

### DIFF
--- a/crates/corrosion-orm-core/src/driver/mod.rs
+++ b/crates/corrosion-orm-core/src/driver/mod.rs
@@ -1,3 +1,5 @@
+//! Driver module for database connections and operations.
+//! This module provides the core driver implementation for database connections, including connection pooling, transactions, and SQL execution.
 pub mod connection;
 pub mod connection_config;
 pub mod connection_pool;

--- a/crates/corrosion-orm-core/src/driver/sqlite_driver/mod.rs
+++ b/crates/corrosion-orm-core/src/driver/sqlite_driver/mod.rs
@@ -1,3 +1,6 @@
+//! SQLite driver module for database connections and operations.
+//! This module provides the SQLite-specific driver implementation, including connection configuration, connection pooling, and SQL execution.
+//! Note: Enable Feature `sqlite` to use this module.
 pub mod sqlite_config;
 pub mod sqlite_connection;
 pub mod sqlite_connection_pool;

--- a/crates/corrosion-orm-core/src/error/mod.rs
+++ b/crates/corrosion-orm-core/src/error/mod.rs
@@ -1,2 +1,4 @@
+//! Error module for Corrosion ORM errors.
+//! It contains the root error enum `CorrosionOrmError` and its implementations.
 pub mod corrosion_orm_error;
 pub use corrosion_orm_error::CorrosionOrmError;

--- a/crates/corrosion-orm-core/src/lib.rs
+++ b/crates/corrosion-orm-core/src/lib.rs
@@ -25,6 +25,7 @@ pub mod prelude {
     pub use crate::driver::executor::Executor;
     pub use crate::driver::sql_driver::SqlDriver;
     pub use crate::driver::transaction::Transaction;
+    pub use crate::error::CorrosionOrmError;
     pub use crate::model::repository::Repo;
     pub use crate::query::*;
     pub use crate::query::{

--- a/crates/corrosion-orm-core/src/model/mod.rs
+++ b/crates/corrosion-orm-core/src/model/mod.rs
@@ -1,1 +1,2 @@
+//! Repository trait for database operations on entities.
 pub mod repository;

--- a/crates/corrosion-orm-core/src/model/repository.rs
+++ b/crates/corrosion-orm-core/src/model/repository.rs
@@ -5,11 +5,24 @@ pub trait Repository<Db: Executor>: Sized + Sync {
     /// The primary key type for this repository.
     type PrimaryKey;
 
+    /// Saves the entity to the database.
+    ///
+    /// Returns the saved entity with any generated fields populated.
     async fn save(&self, db: &mut Db) -> Result<Self, CorrosionOrmError>;
+    /// Returns all entities in the repository.
+    ///
+    /// Returns an empty vector if no entities are found.
     async fn get_all(db: &mut Db) -> Result<Vec<Self>, CorrosionOrmError>;
+    /// Returns the entity with the given primary key, if one exists.
+    ///
+    /// Returns `Ok(None)` if no entity is found.
     async fn get_by_id(
         id: Self::PrimaryKey,
         db: &mut Db,
     ) -> Result<Option<Self>, CorrosionOrmError>;
+    /// Deletes the entity from the database.
+    ///
+    /// Returns `Ok(())` if the entity was deleted, `Ok(None)` if no entity was found, or an error if one occurred.
+    /// Note: this method consumes `self`, so it cannot be called on a borrowed value.
     async fn delete(self, db: &mut Db) -> Result<(), CorrosionOrmError>;
 }

--- a/crates/corrosion-orm-core/src/model/repository.rs
+++ b/crates/corrosion-orm-core/src/model/repository.rs
@@ -2,10 +2,14 @@ use crate::{driver::executor::Executor, error::CorrosionOrmError};
 
 #[trait_variant::make(Repo: Send)]
 pub trait Repository<Db: Executor>: Sized + Sync {
+    /// The primary key type for this repository.
     type PrimaryKey;
 
     async fn save(&self, db: &mut Db) -> Result<Self, CorrosionOrmError>;
     async fn get_all(db: &mut Db) -> Result<Vec<Self>, CorrosionOrmError>;
-    async fn get_by_id(id: Self::PrimaryKey, db: &mut Db) -> Result<Self, CorrosionOrmError>;
+    async fn get_by_id(
+        id: Self::PrimaryKey,
+        db: &mut Db,
+    ) -> Result<Option<Self>, CorrosionOrmError>;
     async fn delete(self, db: &mut Db) -> Result<(), CorrosionOrmError>;
 }

--- a/crates/corrosion-orm-core/src/schema/mod.rs
+++ b/crates/corrosion-orm-core/src/schema/mod.rs
@@ -1,1 +1,2 @@
+//! Schema module for database intermediate representation.
 pub mod table;

--- a/crates/corrosion-orm-macros/src/generator/repository_generate.rs
+++ b/crates/corrosion-orm-macros/src/generator/repository_generate.rs
@@ -36,17 +36,17 @@ pub(crate) fn generate_repository(table: &TableData) -> proc_macro2::TokenStream
 
                 let schema = Self::get_schema();
 
-                let is_new_query = corrosion_orm_core::query::select::Select::from(&schema)
+                let check_query = corrosion_orm_core::query::select::Select::from(&schema)
                     .where_clause(
                         WhereClause::eq(&schema.primary_key.name, self.#pk_ident.clone()),
                 );
 
                 let mut ctx_control = corrosion_orm_core::query::query_type::QueryContext::new();
-                is_new_query.to_sql(&mut ctx_control, db.get_dialect());
-                let is_new = db.execute_query(&mut ctx_control).await?;
+                check_query.to_sql(&mut ctx_control, db.get_dialect());
+                let existing = db.fetch_optional::<Self>(&mut ctx_control).await?;
 
                 let mut ctx = QueryContext::new();
-                if is_new == 0 {
+                if existing.is_none() {
                     let mut insert_query = corrosion_orm_core::query::insert::Insert::from(&schema)
                         .values(self.get_values_from_self());
                     insert_query.to_sql(&mut ctx, db.get_dialect());

--- a/crates/corrosion-orm-macros/src/generator/repository_generate.rs
+++ b/crates/corrosion-orm-macros/src/generator/repository_generate.rs
@@ -78,7 +78,7 @@ pub(crate) fn generate_repository(table: &TableData) -> proc_macro2::TokenStream
                 let results = db.fetch_all::<Self>(&mut ctx).await?;
                 Ok(results)
             }
-            async fn get_by_id(id: Self::PrimaryKey, db: &mut Db) -> Result<Self, corrosion_orm_core::error::CorrosionOrmError> {
+            async fn get_by_id(id: Self::PrimaryKey, db: &mut Db) -> Result<Option<Self>, corrosion_orm_core::error::CorrosionOrmError> {
                 use corrosion_orm_core::query::to_sql::ToSql;
                 use corrosion_orm_core::schema::table::TableSchema;
                 use corrosion_orm_core::query::where_clause::WhereClause;
@@ -90,9 +90,9 @@ pub(crate) fn generate_repository(table: &TableData) -> proc_macro2::TokenStream
                 query.to_sql(&mut ctx, db.get_dialect());
                 let result = db.fetch_optional::<Self>(&mut ctx).await?;
                 if let Some(result) = result {
-                    Ok(result)
+                    Ok(Some(result))
                 } else {
-                    Err(corrosion_orm_core::driver::error::DriverError::NotFound.into())
+                    Ok(None)
                 }
             }
             async fn delete(self, db: &mut Db) -> Result<(), corrosion_orm_core::error::CorrosionOrmError> {

--- a/crates/corrosion-orm-test/src/repository_test/delete_test.rs
+++ b/crates/corrosion-orm-test/src/repository_test/delete_test.rs
@@ -10,7 +10,7 @@ mod tests {
         let mut conn = driver.acquire_conn().await.unwrap();
         user.save(&mut conn).await.unwrap();
         user.delete(&mut conn).await.unwrap();
-        assert!(User::get_by_id(1, &mut conn).await.unwrap().is_none());
+        assert!(User::get_by_id(1, &mut conn).await.is_err());
     }
     #[tokio::test]
     async fn test_delete_not_found() {
@@ -20,7 +20,7 @@ mod tests {
         user.delete(&mut conn).await.unwrap();
     }
     #[tokio::test]
-    async fn test_delete_verifies_removed() -> Result<(), CorrosionOrmError> {
+    async fn test_delete_verifies_removed() {
         let driver = init_sqlite().await;
         let user = User::example();
 
@@ -33,49 +33,43 @@ mod tests {
         drop(conn);
 
         let mut conn = driver.acquire_conn().await.unwrap();
-        let result = User::get_by_id(1, &mut conn).await?;
-        assert!(result.is_none());
-        Ok(())
+        let result = User::get_by_id(1, &mut conn).await;
+        assert!(result.is_err());
     }
 
     #[tokio::test]
-    async fn test_delete_with_transaction() -> Result<(), CorrosionOrmError> {
+    async fn test_delete_with_transaction() {
         let user = User::example();
         let driver = init_sqlite().await;
 
         let mut tx = driver.transaction().await.unwrap();
         user.save(&mut tx).await.unwrap();
 
-        let retrieved_user = User::get_by_id(1, &mut tx).await?.unwrap();
+        let retrieved_user = User::get_by_id(1, &mut tx).await.unwrap();
         assert_eq!(retrieved_user.id, 1);
 
         retrieved_user.delete(&mut tx).await.unwrap();
         tx.commit().await.unwrap();
 
         let mut conn = driver.acquire_conn().await.unwrap();
-        let result = User::get_by_id(1, &mut conn).await?;
-        assert!(result.is_none());
-        Ok(())
+        assert!(User::get_by_id(1, &mut conn).await.is_err());
     }
     #[tokio::test]
-    async fn test_delete_with_transaction_not_found() -> Result<(), CorrosionOrmError> {
+    async fn test_delete_with_transaction_not_found() {
         let driver = init_sqlite().await;
         let mut tx = driver.transaction().await.unwrap();
-        let res = User::get_by_id(1, &mut tx).await?;
-        assert!(res.is_none());
+        let res = User::get_by_id(1, &mut tx).await;
+        assert!(res.is_err());
         tx.commit().await.unwrap();
-        Ok(())
     }
     #[tokio::test]
-    async fn test_delete_with_transaction_rollback() -> Result<(), CorrosionOrmError> {
+    async fn test_delete_with_transaction_rollback() {
         let user = User::example();
         let driver = init_sqlite().await;
         let mut tx = driver.transaction().await.unwrap();
         user.save(&mut tx).await.unwrap();
         tx.rollback().await.unwrap();
         let mut conn = driver.acquire_conn().await.unwrap();
-        let result = User::get_by_id(1, &mut conn).await?;
-        assert!(result.is_none());
-        Ok(())
+        assert!(User::get_by_id(1, &mut conn).await.is_err());
     }
 }

--- a/crates/corrosion-orm-test/src/repository_test/delete_test.rs
+++ b/crates/corrosion-orm-test/src/repository_test/delete_test.rs
@@ -10,7 +10,7 @@ mod tests {
         let mut conn = driver.acquire_conn().await.unwrap();
         user.save(&mut conn).await.unwrap();
         user.delete(&mut conn).await.unwrap();
-        assert!(User::get_by_id(1, &mut conn).await.is_err());
+        assert!(User::get_by_id(1, &mut conn).await.unwrap().is_none());
     }
     #[tokio::test]
     async fn test_delete_not_found() {
@@ -20,7 +20,7 @@ mod tests {
         user.delete(&mut conn).await.unwrap();
     }
     #[tokio::test]
-    async fn test_delete_verifies_removed() {
+    async fn test_delete_verifies_removed() -> Result<(), CorrosionOrmError> {
         let driver = init_sqlite().await;
         let user = User::example();
 
@@ -33,43 +33,49 @@ mod tests {
         drop(conn);
 
         let mut conn = driver.acquire_conn().await.unwrap();
-        let result = User::get_by_id(1, &mut conn).await;
-        assert!(result.is_err());
+        let result = User::get_by_id(1, &mut conn).await?;
+        assert!(result.is_none());
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_delete_with_transaction() {
+    async fn test_delete_with_transaction() -> Result<(), CorrosionOrmError> {
         let user = User::example();
         let driver = init_sqlite().await;
 
         let mut tx = driver.transaction().await.unwrap();
         user.save(&mut tx).await.unwrap();
 
-        let retrieved_user = User::get_by_id(1, &mut tx).await.unwrap();
+        let retrieved_user = User::get_by_id(1, &mut tx).await?.unwrap();
         assert_eq!(retrieved_user.id, 1);
 
         retrieved_user.delete(&mut tx).await.unwrap();
         tx.commit().await.unwrap();
 
         let mut conn = driver.acquire_conn().await.unwrap();
-        assert!(User::get_by_id(1, &mut conn).await.is_err());
+        let result = User::get_by_id(1, &mut conn).await?;
+        assert!(result.is_none());
+        Ok(())
     }
     #[tokio::test]
-    async fn test_delete_with_transaction_not_found() {
+    async fn test_delete_with_transaction_not_found() -> Result<(), CorrosionOrmError> {
         let driver = init_sqlite().await;
         let mut tx = driver.transaction().await.unwrap();
-        let res = User::get_by_id(1, &mut tx).await;
-        assert!(res.is_err());
+        let res = User::get_by_id(1, &mut tx).await?;
+        assert!(res.is_none());
         tx.commit().await.unwrap();
+        Ok(())
     }
     #[tokio::test]
-    async fn test_delete_with_transaction_rollback() {
+    async fn test_delete_with_transaction_rollback() -> Result<(), CorrosionOrmError> {
         let user = User::example();
         let driver = init_sqlite().await;
         let mut tx = driver.transaction().await.unwrap();
         user.save(&mut tx).await.unwrap();
         tx.rollback().await.unwrap();
         let mut conn = driver.acquire_conn().await.unwrap();
-        assert!(User::get_by_id(1, &mut conn).await.is_err());
+        let result = User::get_by_id(1, &mut conn).await?;
+        assert!(result.is_none());
+        Ok(())
     }
 }

--- a/crates/corrosion-orm-test/src/repository_test/delete_test.rs
+++ b/crates/corrosion-orm-test/src/repository_test/delete_test.rs
@@ -10,5 +10,66 @@ mod tests {
         let mut conn = driver.acquire_conn().await.unwrap();
         user.save(&mut conn).await.unwrap();
         user.delete(&mut conn).await.unwrap();
+        assert!(User::get_by_id(1, &mut conn).await.is_err());
+    }
+    #[tokio::test]
+    async fn test_delete_not_found() {
+        let user = User::example();
+        let driver = init_sqlite().await;
+        let mut conn = driver.acquire_conn().await.unwrap();
+        user.delete(&mut conn).await.unwrap();
+    }
+    #[tokio::test]
+    async fn test_delete_verifies_removed() {
+        let driver = init_sqlite().await;
+        let user = User::example();
+
+        let mut conn = driver.acquire_conn().await.unwrap();
+        user.save(&mut conn).await.unwrap();
+        drop(conn);
+
+        let mut conn = driver.acquire_conn().await.unwrap();
+        user.delete(&mut conn).await.unwrap();
+        drop(conn);
+
+        let mut conn = driver.acquire_conn().await.unwrap();
+        let result = User::get_by_id(1, &mut conn).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_delete_with_transaction() {
+        let user = User::example();
+        let driver = init_sqlite().await;
+
+        let mut tx = driver.transaction().await.unwrap();
+        user.save(&mut tx).await.unwrap();
+
+        let retrieved_user = User::get_by_id(1, &mut tx).await.unwrap();
+        assert_eq!(retrieved_user.id, 1);
+
+        retrieved_user.delete(&mut tx).await.unwrap();
+        tx.commit().await.unwrap();
+
+        let mut conn = driver.acquire_conn().await.unwrap();
+        assert!(User::get_by_id(1, &mut conn).await.is_err());
+    }
+    #[tokio::test]
+    async fn test_delete_with_transaction_not_found() {
+        let driver = init_sqlite().await;
+        let mut tx = driver.transaction().await.unwrap();
+        let res = User::get_by_id(1, &mut tx).await;
+        assert!(res.is_err());
+        tx.commit().await.unwrap();
+    }
+    #[tokio::test]
+    async fn test_delete_with_transaction_rollback() {
+        let user = User::example();
+        let driver = init_sqlite().await;
+        let mut tx = driver.transaction().await.unwrap();
+        user.save(&mut tx).await.unwrap();
+        tx.rollback().await.unwrap();
+        let mut conn = driver.acquire_conn().await.unwrap();
+        assert!(User::get_by_id(1, &mut conn).await.is_err());
     }
 }

--- a/crates/corrosion-orm-test/src/repository_test/get_test.rs
+++ b/crates/corrosion-orm-test/src/repository_test/get_test.rs
@@ -4,21 +4,23 @@ mod tests {
     use corrosion_orm_core::prelude::*;
 
     #[tokio::test]
-    async fn test_get_by_id() {
+    async fn test_get_by_id() -> Result<(), CorrosionOrmError> {
         let driver = init_sqlite().await;
 
         let user = User::example();
         let mut conn = driver.acquire_conn().await.unwrap();
         user.save(&mut conn).await.unwrap();
-        let db_user = User::get_by_id(user.id, &mut conn).await.unwrap();
+        let db_user = User::get_by_id(user.id, &mut conn).await?.unwrap();
         assert_eq!(user.id, db_user.id);
+        Ok(())
     }
     #[tokio::test]
-    async fn test_get_by_id_not_found() {
+    async fn test_get_by_id_not_found() -> Result<(), CorrosionOrmError> {
         let driver = init_sqlite().await;
         let mut conn = driver.acquire_conn().await.unwrap();
-        let result = User::get_by_id(999, &mut conn).await;
-        assert!(result.is_err());
+        let result = User::get_by_id(999, &mut conn).await?;
+        assert!(result.is_none());
+        Ok(())
     }
     #[tokio::test]
     async fn test_get_all() {
@@ -55,25 +57,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_get_by_id_with_transaction() {
+    async fn test_get_by_id_with_transaction() -> Result<(), CorrosionOrmError> {
         let user = User::example();
         let driver = init_sqlite().await;
 
         let mut tx = driver.transaction().await.unwrap();
         user.save(&mut tx).await.unwrap();
 
-        let retrieved_user = User::get_by_id(user.id, &mut tx).await.unwrap();
+        let retrieved_user = User::get_by_id(user.id, &mut tx).await?.unwrap();
         assert_eq!(retrieved_user.id, user.id);
 
         tx.commit().await.unwrap();
 
         let mut conn = driver.acquire_conn().await.unwrap();
-        let db_user = User::get_by_id(user.id, &mut conn).await.unwrap();
+        let db_user = User::get_by_id(user.id, &mut conn).await?.unwrap();
         assert_eq!(user.id, db_user.id);
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_get_all_with_transaction() {
+    async fn test_get_all_with_transaction() -> Result<(), CorrosionOrmError> {
         let driver = init_sqlite().await;
 
         let mut tx = driver.transaction().await.unwrap();
@@ -93,19 +96,21 @@ mod tests {
         let mut conn = driver.acquire_conn().await.unwrap();
         let db_users = User::get_all(&mut conn).await.unwrap();
         assert_eq!(5, db_users.len());
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_get_with_transaction_not_found() {
+    async fn test_get_with_transaction_not_found() -> Result<(), CorrosionOrmError> {
         let driver = init_sqlite().await;
         let mut tx = driver.transaction().await.unwrap();
-        let result = User::get_by_id(999, &mut tx).await;
-        assert!(result.is_err());
+        let result = User::get_by_id(999, &mut tx).await?;
+        assert!(result.is_none());
         tx.commit().await.unwrap();
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_get_with_transaction_after_rollback() {
+    async fn test_get_with_transaction_after_rollback() -> Result<(), CorrosionOrmError> {
         let user = User::example();
         let driver = init_sqlite().await;
 
@@ -114,7 +119,8 @@ mod tests {
         tx.rollback().await.unwrap();
 
         let mut conn = driver.acquire_conn().await.unwrap();
-        let result = User::get_by_id(user.id, &mut conn).await;
-        assert!(result.is_err());
+        let result = User::get_by_id(user.id, &mut conn).await?;
+        assert!(result.is_none());
+        Ok(())
     }
 }

--- a/crates/corrosion-orm-test/src/repository_test/get_test.rs
+++ b/crates/corrosion-orm-test/src/repository_test/get_test.rs
@@ -4,23 +4,21 @@ mod tests {
     use corrosion_orm_core::prelude::*;
 
     #[tokio::test]
-    async fn test_get_by_id() -> Result<(), CorrosionOrmError> {
+    async fn test_get_by_id() {
         let driver = init_sqlite().await;
 
         let user = User::example();
         let mut conn = driver.acquire_conn().await.unwrap();
         user.save(&mut conn).await.unwrap();
-        let db_user = User::get_by_id(user.id, &mut conn).await?.unwrap();
+        let db_user = User::get_by_id(user.id, &mut conn).await.unwrap();
         assert_eq!(user.id, db_user.id);
-        Ok(())
     }
     #[tokio::test]
-    async fn test_get_by_id_not_found() -> Result<(), CorrosionOrmError> {
+    async fn test_get_by_id_not_found() {
         let driver = init_sqlite().await;
         let mut conn = driver.acquire_conn().await.unwrap();
-        let result = User::get_by_id(999, &mut conn).await?;
-        assert!(result.is_none());
-        Ok(())
+        let result = User::get_by_id(999, &mut conn).await;
+        assert!(result.is_err());
     }
     #[tokio::test]
     async fn test_get_all() {
@@ -57,26 +55,25 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_get_by_id_with_transaction() -> Result<(), CorrosionOrmError> {
+    async fn test_get_by_id_with_transaction() {
         let user = User::example();
         let driver = init_sqlite().await;
 
         let mut tx = driver.transaction().await.unwrap();
         user.save(&mut tx).await.unwrap();
 
-        let retrieved_user = User::get_by_id(user.id, &mut tx).await?.unwrap();
+        let retrieved_user = User::get_by_id(user.id, &mut tx).await.unwrap();
         assert_eq!(retrieved_user.id, user.id);
 
         tx.commit().await.unwrap();
 
         let mut conn = driver.acquire_conn().await.unwrap();
-        let db_user = User::get_by_id(user.id, &mut conn).await?.unwrap();
+        let db_user = User::get_by_id(user.id, &mut conn).await.unwrap();
         assert_eq!(user.id, db_user.id);
-        Ok(())
     }
 
     #[tokio::test]
-    async fn test_get_all_with_transaction() -> Result<(), CorrosionOrmError> {
+    async fn test_get_all_with_transaction() {
         let driver = init_sqlite().await;
 
         let mut tx = driver.transaction().await.unwrap();
@@ -96,21 +93,19 @@ mod tests {
         let mut conn = driver.acquire_conn().await.unwrap();
         let db_users = User::get_all(&mut conn).await.unwrap();
         assert_eq!(5, db_users.len());
-        Ok(())
     }
 
     #[tokio::test]
-    async fn test_get_with_transaction_not_found() -> Result<(), CorrosionOrmError> {
+    async fn test_get_with_transaction_not_found() {
         let driver = init_sqlite().await;
         let mut tx = driver.transaction().await.unwrap();
-        let result = User::get_by_id(999, &mut tx).await?;
-        assert!(result.is_none());
+        let result = User::get_by_id(999, &mut tx).await;
+        assert!(result.is_err());
         tx.commit().await.unwrap();
-        Ok(())
     }
 
     #[tokio::test]
-    async fn test_get_with_transaction_after_rollback() -> Result<(), CorrosionOrmError> {
+    async fn test_get_with_transaction_after_rollback() {
         let user = User::example();
         let driver = init_sqlite().await;
 
@@ -119,8 +114,7 @@ mod tests {
         tx.rollback().await.unwrap();
 
         let mut conn = driver.acquire_conn().await.unwrap();
-        let result = User::get_by_id(user.id, &mut conn).await?;
-        assert!(result.is_none());
-        Ok(())
+        let result = User::get_by_id(user.id, &mut conn).await;
+        assert!(result.is_err());
     }
 }

--- a/crates/corrosion-orm-test/src/repository_test/get_test.rs
+++ b/crates/corrosion-orm-test/src/repository_test/get_test.rs
@@ -1,0 +1,120 @@
+#[cfg(test)]
+mod tests {
+    use crate::{init_sqlite, test_entities::User};
+    use corrosion_orm_core::prelude::*;
+
+    #[tokio::test]
+    async fn test_get_by_id() {
+        let driver = init_sqlite().await;
+
+        let user = User::example();
+        let mut conn = driver.acquire_conn().await.unwrap();
+        user.save(&mut conn).await.unwrap();
+        let db_user = User::get_by_id(user.id, &mut conn).await.unwrap();
+        assert_eq!(user.id, db_user.id);
+    }
+    #[tokio::test]
+    async fn test_get_by_id_not_found() {
+        let driver = init_sqlite().await;
+        let mut conn = driver.acquire_conn().await.unwrap();
+        let result = User::get_by_id(999, &mut conn).await;
+        assert!(result.is_err());
+    }
+    #[tokio::test]
+    async fn test_get_all() {
+        let driver = init_sqlite().await;
+        let mut conn = driver.acquire_conn().await.unwrap();
+        let user = User::example();
+        user.save(&mut conn).await.unwrap();
+        let users = User::get_all(&mut conn).await.unwrap();
+        assert_eq!(1, users.len());
+    }
+    #[tokio::test]
+    async fn test_get_all_empty() {
+        let driver = init_sqlite().await;
+        let mut conn = driver.acquire_conn().await.unwrap();
+        let users = User::get_all(&mut conn).await.unwrap();
+        assert!(users.is_empty());
+    }
+    #[tokio::test]
+    async fn test_get_all_multiple() {
+        let driver = init_sqlite().await;
+        let mut conn = driver.acquire_conn().await.unwrap();
+        for i in 0..10 {
+            let user = User {
+                id: i,
+                name: format!("user{}", i),
+            };
+            user.save(&mut conn).await.unwrap();
+        }
+        let users = User::get_all(&mut conn).await.unwrap();
+        assert_eq!(10, users.len());
+        for (i, user) in users.iter().enumerate() {
+            assert_eq!(i, user.id as usize);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_by_id_with_transaction() {
+        let user = User::example();
+        let driver = init_sqlite().await;
+
+        let mut tx = driver.transaction().await.unwrap();
+        user.save(&mut tx).await.unwrap();
+
+        let retrieved_user = User::get_by_id(user.id, &mut tx).await.unwrap();
+        assert_eq!(retrieved_user.id, user.id);
+
+        tx.commit().await.unwrap();
+
+        let mut conn = driver.acquire_conn().await.unwrap();
+        let db_user = User::get_by_id(user.id, &mut conn).await.unwrap();
+        assert_eq!(user.id, db_user.id);
+    }
+
+    #[tokio::test]
+    async fn test_get_all_with_transaction() {
+        let driver = init_sqlite().await;
+
+        let mut tx = driver.transaction().await.unwrap();
+        for i in 0..5 {
+            let user = User {
+                id: i,
+                name: format!("user{}", i),
+            };
+            user.save(&mut tx).await.unwrap();
+        }
+
+        let users = User::get_all(&mut tx).await.unwrap();
+        assert_eq!(5, users.len());
+
+        tx.commit().await.unwrap();
+
+        let mut conn = driver.acquire_conn().await.unwrap();
+        let db_users = User::get_all(&mut conn).await.unwrap();
+        assert_eq!(5, db_users.len());
+    }
+
+    #[tokio::test]
+    async fn test_get_with_transaction_not_found() {
+        let driver = init_sqlite().await;
+        let mut tx = driver.transaction().await.unwrap();
+        let result = User::get_by_id(999, &mut tx).await;
+        assert!(result.is_err());
+        tx.commit().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_get_with_transaction_after_rollback() {
+        let user = User::example();
+        let driver = init_sqlite().await;
+
+        let mut tx = driver.transaction().await.unwrap();
+        user.save(&mut tx).await.unwrap();
+        tx.rollback().await.unwrap();
+
+        let mut conn = driver.acquire_conn().await.unwrap();
+        let result = User::get_by_id(user.id, &mut conn).await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/corrosion-orm-test/src/repository_test/mod.rs
+++ b/crates/corrosion-orm-test/src/repository_test/mod.rs
@@ -1,2 +1,3 @@
 mod delete_test;
+mod get_test;
 mod save_test;

--- a/crates/corrosion-orm-test/src/repository_test/save_test.rs
+++ b/crates/corrosion-orm-test/src/repository_test/save_test.rs
@@ -23,7 +23,7 @@ mod tests {
         assert!(result.is_ok());
     }
     #[tokio::test]
-    async fn test_save_update() -> Result<(), CorrosionOrmError> {
+    async fn test_save_update() {
         let user = User::example();
         let driver = init_sqlite().await;
         let mut conn = driver.acquire_conn().await.unwrap();
@@ -33,12 +33,11 @@ mod tests {
         let mut updated_user = User::example();
         updated_user.name = String::from("Alice");
         updated_user.save(&mut conn).await.unwrap();
-        let result = User::get_by_id(1, &mut conn).await?.unwrap();
-        assert_eq!(result.name, "Alice");
-        Ok(())
+        let result = User::get_by_id(1, &mut conn).await.unwrap();
+        assert_eq!(result.name, "Alice")
     }
     #[tokio::test]
-    async fn test_save_with_transaction_commit() -> Result<(), CorrosionOrmError> {
+    async fn test_save_with_transaction_commit() {
         let user = User::example();
         let driver = init_sqlite().await;
 
@@ -47,13 +46,13 @@ mod tests {
         tx.commit().await.unwrap();
 
         let mut conn = driver.acquire_conn().await.unwrap();
-        let result = User::get_by_id(1, &mut conn).await?.unwrap();
-        assert_eq!(result.id, 1);
-        Ok(())
+        let result = User::get_by_id(1, &mut conn).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().id, 1);
     }
 
     #[tokio::test]
-    async fn test_save_with_transaction_rollback() -> Result<(), CorrosionOrmError> {
+    async fn test_save_with_transaction_rollback() {
         let user = User::example();
         let driver = init_sqlite().await;
 
@@ -62,13 +61,12 @@ mod tests {
         tx.rollback().await.unwrap();
 
         let mut conn = driver.acquire_conn().await.unwrap();
-        let result = User::get_by_id(1, &mut conn).await?;
-        assert!(result.is_none());
-        Ok(())
+        let result = User::get_by_id(1, &mut conn).await;
+        assert!(result.is_err());
     }
 
     #[tokio::test]
-    async fn test_save_update_with_transaction_commit() -> Result<(), CorrosionOrmError> {
+    async fn test_save_update_with_transaction_commit() {
         let user = User::example();
         let driver = init_sqlite().await;
 
@@ -77,19 +75,18 @@ mod tests {
         drop(conn);
 
         let mut tx = driver.transaction().await.unwrap();
-        let mut updated_user = User::get_by_id(1, &mut tx).await?.unwrap();
+        let mut updated_user = User::get_by_id(1, &mut tx).await.unwrap();
         updated_user.name = String::from("Alice");
         updated_user.save(&mut tx).await.unwrap();
         tx.commit().await.unwrap();
 
         let mut conn = driver.acquire_conn().await.unwrap();
-        let result = User::get_by_id(1, &mut conn).await?.unwrap();
+        let result = User::get_by_id(1, &mut conn).await.unwrap();
         assert_eq!(result.name, "Alice");
-        Ok(())
     }
 
     #[tokio::test]
-    async fn test_save_multiple_with_transaction_commit() -> Result<(), CorrosionOrmError> {
+    async fn test_save_multiple_with_transaction_commit() {
         let driver = init_sqlite().await;
 
         let mut tx = driver.transaction().await.unwrap();
@@ -122,9 +119,8 @@ mod tests {
         assert!(result1.is_ok());
         assert!(result2.is_ok());
         assert!(result3.is_ok());
-        assert_eq!(result1?.unwrap().name, "Alice");
-        assert_eq!(result2?.unwrap().name, "Bob");
-        assert_eq!(result3?.unwrap().name, "Charlie");
-        Ok(())
+        assert_eq!(result1.unwrap().name, "Alice");
+        assert_eq!(result2.unwrap().name, "Bob");
+        assert_eq!(result3.unwrap().name, "Charlie");
     }
 }

--- a/crates/corrosion-orm-test/src/repository_test/save_test.rs
+++ b/crates/corrosion-orm-test/src/repository_test/save_test.rs
@@ -11,4 +11,116 @@ mod tests {
         user.save(&mut conn).await.unwrap();
         let _saved_user = user.save(&mut conn).await.unwrap();
     }
+    #[tokio::test]
+    async fn test_save_verifies_saved() {
+        let user = User::example();
+        let driver = init_sqlite().await;
+        let mut conn = driver.acquire_conn().await.unwrap();
+        user.save(&mut conn).await.unwrap();
+        drop(conn);
+        let mut conn = driver.acquire_conn().await.unwrap();
+        let result = User::get_by_id(1, &mut conn).await;
+        assert!(result.is_ok());
+    }
+    #[tokio::test]
+    async fn test_save_update() {
+        let user = User::example();
+        let driver = init_sqlite().await;
+        let mut conn = driver.acquire_conn().await.unwrap();
+        user.save(&mut conn).await.unwrap();
+        drop(conn);
+        let mut conn = driver.acquire_conn().await.unwrap();
+        let mut updated_user = User::example();
+        updated_user.name = String::from("Alice");
+        updated_user.save(&mut conn).await.unwrap();
+        let result = User::get_by_id(1, &mut conn).await.unwrap();
+        assert_eq!(result.name, "Alice")
+    }
+    #[tokio::test]
+    async fn test_save_with_transaction_commit() {
+        let user = User::example();
+        let driver = init_sqlite().await;
+
+        let mut tx = driver.transaction().await.unwrap();
+        user.save(&mut tx).await.unwrap();
+        tx.commit().await.unwrap();
+
+        let mut conn = driver.acquire_conn().await.unwrap();
+        let result = User::get_by_id(1, &mut conn).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().id, 1);
+    }
+
+    #[tokio::test]
+    async fn test_save_with_transaction_rollback() {
+        let user = User::example();
+        let driver = init_sqlite().await;
+
+        let mut tx = driver.transaction().await.unwrap();
+        user.save(&mut tx).await.unwrap();
+        tx.rollback().await.unwrap();
+
+        let mut conn = driver.acquire_conn().await.unwrap();
+        let result = User::get_by_id(1, &mut conn).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_save_update_with_transaction_commit() {
+        let user = User::example();
+        let driver = init_sqlite().await;
+
+        let mut conn = driver.acquire_conn().await.unwrap();
+        user.save(&mut conn).await.unwrap();
+        drop(conn);
+
+        let mut tx = driver.transaction().await.unwrap();
+        let mut updated_user = User::get_by_id(1, &mut tx).await.unwrap();
+        updated_user.name = String::from("Alice");
+        updated_user.save(&mut tx).await.unwrap();
+        tx.commit().await.unwrap();
+
+        let mut conn = driver.acquire_conn().await.unwrap();
+        let result = User::get_by_id(1, &mut conn).await.unwrap();
+        assert_eq!(result.name, "Alice");
+    }
+
+    #[tokio::test]
+    async fn test_save_multiple_with_transaction_commit() {
+        let driver = init_sqlite().await;
+
+        let mut tx = driver.transaction().await.unwrap();
+
+        let user1 = User {
+            id: 1,
+            name: String::from("Alice"),
+        };
+        user1.save(&mut tx).await.unwrap();
+
+        let user2 = User {
+            id: 2,
+            name: String::from("Bob"),
+        };
+        user2.save(&mut tx).await.unwrap();
+
+        let user3 = User {
+            id: 3,
+            name: String::from("Charlie"),
+        };
+        user3.save(&mut tx).await.unwrap();
+
+        tx.commit().await.unwrap();
+
+        let mut conn = driver.acquire_conn().await.unwrap();
+        let result1 = User::get_by_id(1, &mut conn).await;
+        let result2 = User::get_by_id(2, &mut conn).await;
+        let result3 = User::get_by_id(3, &mut conn).await;
+
+        assert!(result1.is_ok());
+        assert!(result2.is_ok());
+        assert!(result3.is_ok());
+        assert_eq!(result1.unwrap().name, "Alice");
+        assert_eq!(result2.unwrap().name, "Bob");
+        assert_eq!(result3.unwrap().name, "Charlie");
+    }
 }

--- a/crates/corrosion-orm-test/src/repository_test/save_test.rs
+++ b/crates/corrosion-orm-test/src/repository_test/save_test.rs
@@ -23,7 +23,7 @@ mod tests {
         assert!(result.is_ok());
     }
     #[tokio::test]
-    async fn test_save_update() {
+    async fn test_save_update() -> Result<(), CorrosionOrmError> {
         let user = User::example();
         let driver = init_sqlite().await;
         let mut conn = driver.acquire_conn().await.unwrap();
@@ -33,11 +33,12 @@ mod tests {
         let mut updated_user = User::example();
         updated_user.name = String::from("Alice");
         updated_user.save(&mut conn).await.unwrap();
-        let result = User::get_by_id(1, &mut conn).await.unwrap();
-        assert_eq!(result.name, "Alice")
+        let result = User::get_by_id(1, &mut conn).await?.unwrap();
+        assert_eq!(result.name, "Alice");
+        Ok(())
     }
     #[tokio::test]
-    async fn test_save_with_transaction_commit() {
+    async fn test_save_with_transaction_commit() -> Result<(), CorrosionOrmError> {
         let user = User::example();
         let driver = init_sqlite().await;
 
@@ -46,13 +47,13 @@ mod tests {
         tx.commit().await.unwrap();
 
         let mut conn = driver.acquire_conn().await.unwrap();
-        let result = User::get_by_id(1, &mut conn).await;
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().id, 1);
+        let result = User::get_by_id(1, &mut conn).await?.unwrap();
+        assert_eq!(result.id, 1);
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_save_with_transaction_rollback() {
+    async fn test_save_with_transaction_rollback() -> Result<(), CorrosionOrmError> {
         let user = User::example();
         let driver = init_sqlite().await;
 
@@ -61,12 +62,13 @@ mod tests {
         tx.rollback().await.unwrap();
 
         let mut conn = driver.acquire_conn().await.unwrap();
-        let result = User::get_by_id(1, &mut conn).await;
-        assert!(result.is_err());
+        let result = User::get_by_id(1, &mut conn).await?;
+        assert!(result.is_none());
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_save_update_with_transaction_commit() {
+    async fn test_save_update_with_transaction_commit() -> Result<(), CorrosionOrmError> {
         let user = User::example();
         let driver = init_sqlite().await;
 
@@ -75,18 +77,19 @@ mod tests {
         drop(conn);
 
         let mut tx = driver.transaction().await.unwrap();
-        let mut updated_user = User::get_by_id(1, &mut tx).await.unwrap();
+        let mut updated_user = User::get_by_id(1, &mut tx).await?.unwrap();
         updated_user.name = String::from("Alice");
         updated_user.save(&mut tx).await.unwrap();
         tx.commit().await.unwrap();
 
         let mut conn = driver.acquire_conn().await.unwrap();
-        let result = User::get_by_id(1, &mut conn).await.unwrap();
+        let result = User::get_by_id(1, &mut conn).await?.unwrap();
         assert_eq!(result.name, "Alice");
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_save_multiple_with_transaction_commit() {
+    async fn test_save_multiple_with_transaction_commit() -> Result<(), CorrosionOrmError> {
         let driver = init_sqlite().await;
 
         let mut tx = driver.transaction().await.unwrap();
@@ -119,8 +122,9 @@ mod tests {
         assert!(result1.is_ok());
         assert!(result2.is_ok());
         assert!(result3.is_ok());
-        assert_eq!(result1.unwrap().name, "Alice");
-        assert_eq!(result2.unwrap().name, "Bob");
-        assert_eq!(result3.unwrap().name, "Charlie");
+        assert_eq!(result1?.unwrap().name, "Alice");
+        assert_eq!(result2?.unwrap().name, "Bob");
+        assert_eq!(result3?.unwrap().name, "Charlie");
+        Ok(())
     }
 }

--- a/crates/corrosion-orm-test/src/test_entities.rs
+++ b/crates/corrosion-orm-test/src/test_entities.rs
@@ -38,7 +38,8 @@ pub(crate) async fn init_sqlite() -> SqliteDriver {
 
     let _ = env_logger::builder()
         .is_test(true)
-        .filter_level(log::LevelFilter::Info)
+        .filter_level(log::LevelFilter::max())
+        .filter_module("sqlx", log::LevelFilter::Off)
         .try_init();
 
     let config = SqliteConfigBuilder::new()


### PR DESCRIPTION
This pull request refines the Corrosion ORM core and macro crates by improving the `Repository` trait API, updating macro-generated code, and enhancing test coverage for repository operations. The changes make `get_by_id` return an `Option`, clarify documentation, and add comprehensive tests for CRUD operations, including transactional scenarios.

**Repository trait and macro improvements:**

* Changed the `Repository` trait's `get_by_id` method to return `Result<Option<Self>, CorrosionOrmError>` instead of returning an error when not found, and updated documentation/comments for all trait methods.
* Updated macro-generated repository implementations to match the new `get_by_id` signature and logic, returning `Ok(None)` instead of an error when no entity is found. [[1]](diffhunk://#diff-428e7bb3709d8c1c7c92edb7cc078395676c899c2105ac2714d1bb738e1d0f88L39-R49) [[2]](diffhunk://#diff-428e7bb3709d8c1c7c92edb7cc078395676c899c2105ac2714d1bb738e1d0f88L81-R81) [[3]](diffhunk://#diff-428e7bb3709d8c1c7c92edb7cc078395676c899c2105ac2714d1bb738e1d0f88L93-R95)

**Testing enhancements:**

* Added comprehensive tests for `get_by_id`, `get_all`, and various transaction scenarios to ensure correct repository behavior, including edge cases and rollback/commit logic. [[1]](diffhunk://#diff-3c444abe48c3bda66bc16936946e27113dc1aa02cc437664267734e039042d2fR1-R126) [[2]](diffhunk://#diff-04eec7eeae626da42300a91f4ac98f63e2ee1fd3f62cf48585301d2a73bf4e65R13-R79) [[3]](diffhunk://#diff-21a32c6e6a1cc287ca064bf1d8da1407b6a8506f37d762f250d498a68fb1870bR14-R129)
* Registered the new test module for repository get operations.

**Documentation and module-level improvements:**

* Added module-level documentation comments to `driver`, `sqlite_driver`, `error`, `model`, and `schema` modules for clarity and maintainability. [[1]](diffhunk://#diff-dbb4d3f0a1dcb5a257e2c6d4d0d4691da329135b13ad14596fb0a3ff2eaaaa0bR1-R2) [[2]](diffhunk://#diff-584d1b9828d9a9b33a95bb5554bb3eb3efe15b2ff2b327ac94894e0b843d13afR1-R3) [[3]](diffhunk://#diff-9b887016825175f73fc4cc0694d0b5e318e262f0939655a28f416d72aebca8c8R1-R2) [[4]](diffhunk://#diff-300709b08a1ef5034ec828b1a7d0c1361178c50d186403d6e12efa7c365e5a34R1) [[5]](diffhunk://#diff-3ed046b83b17ac4f4183c97a3ab6d6990d8cbe4d6f74ee5b7f9317106bfa5bdcR1)
* Exposed `CorrosionOrmError` in the `prelude` for easier imports.

**Test infrastructure:**

* Improved logging configuration in the test entity setup to suppress verbose output from dependencies.