### PR TITLE
feat: Index parsing

### DIFF
--- a/crates/corrosion-orm-core/src/dialect/sql_dialect.rs
+++ b/crates/corrosion-orm-core/src/dialect/sql_dialect.rs
@@ -70,13 +70,17 @@ pub trait SqlDialect: Send + Sync {
         for field in &schema.fields {
             columns.push(self.cast_column(field));
         }
-
-        Ok(format!(
+        let mut ddl = format!(
             "CREATE TABLE {}{} (\n{}\n);\n",
             guard,
             schema.name,
             columns.join(",\n")
-        ))
+        );
+        for index in &schema.indexes {
+            ddl.push_str(&self.generate_create_index_ddl(&schema.name, index));
+        }
+
+        Ok(ddl)
     }
 
     /// Generates `DROP TABLE <name>;`.

--- a/crates/corrosion-orm-macros/src/generator/schema_generate.rs
+++ b/crates/corrosion-orm-macros/src/generator/schema_generate.rs
@@ -11,6 +11,11 @@ pub fn generate_schema_impl(table: &TableData) -> TokenStream {
         fields.push(generate_field(field));
     }
 
+    let mut indexes: Vec<TokenStream> = Vec::new();
+    for index in table.indexes.iter() {
+        indexes.push(generate_index(index));
+    }
+
     let table_name = &table.name;
     let struct_ident = &table.ident;
 
@@ -25,13 +30,14 @@ pub fn generate_schema_impl(table: &TableData) -> TokenStream {
                 corrosion_orm_core::schema::table::TableSchemaModel{
                     name: String::from(#table_name),
                     fields: vec!(#(#fields),*),
-                    indexes: Vec::new(),
+                    indexes: vec!(#(#indexes),*),
                     primary_key: #primary_key
                 }
             }
         }
     }
 }
+
 fn generate_field(field: &Field) -> TokenStream {
     let field_name = &field.name;
     let field_type = &field.ty;
@@ -56,6 +62,21 @@ fn generate_field(field: &Field) -> TokenStream {
         )
     }
 }
+
+fn generate_index(index: &crate::model::IndexDefinition) -> TokenStream {
+    let index_name = &index.name;
+    let index_fields: Vec<String> = index.fields.clone();
+    let is_unique = index.unique;
+
+    quote! {
+        corrosion_orm_core::schema::table::IndexModel {
+            name: String::from(#index_name),
+            fields: vec!(#(String::from(#index_fields)),*),
+            unique: #is_unique,
+        }
+    }
+}
+
 fn generate_primary_key(primary_key: &PrimaryKeyField) -> TokenStream {
     let key_name = &primary_key.name;
     let strategy = match &primary_key.generation_strategy {

--- a/crates/corrosion-orm-macros/src/lib.rs
+++ b/crates/corrosion-orm-macros/src/lib.rs
@@ -16,53 +16,105 @@ use syn::{DeriveInput, parse_macro_input};
 /// ### Placed at top of struct
 ///
 /// `#[Table]`
-/// possible attributes=> name: String
+/// Possible attributes => name: String
+///
+/// `#[Index]`
+/// Possible attributes => name: String (optional, auto-generated if omitted),
+///                        fields: Vec<String> (required),
+///                        unique: bool (optional, default = false)
 ///
 /// ### Example
 /// ```ignore
 /// #[derive(Model)]
 /// #[Table(name = "users")]
+/// #[Index(name = "idx_email", fields = ["email"], unique = true)]
 /// struct User;
 /// ```
 ///
 /// ### Placed above field of the struct
 ///
 /// `#[Column]`
-///  possible attributes=> name: String,unique: bool,nullable: bool
+///  Possible attributes => name: String,
+///                         unique: bool,
+///                         nullable: bool,
+///                         index: bool (optional, creates single-column index)
 ///
 /// # Example
 /// ```ignore
-/// #[Model]
+/// #[derive(Model)]
 /// struct User {
-///     #[Column(name= "nm",unique = true,nullable = false)]
+///     #[Column(name = "nm", unique = true, nullable = false)]
 ///     name: String
-///}
+/// }
 /// ```
 ///
 /// `#[PrimaryKey]`
-/// possible attributes=> generation_strategy: GenerationStrategy
+/// Possible attributes => generation_strategy: GenerationStrategy
+///
 /// # Example
 /// ```ignore
-/// #[Model]
+/// #[derive(Model)]
 /// struct User {
-///     #[Column(name= "nm",unique = true,nullable = false)]
+///     #[Column(name = "nm", unique = true, nullable = false)]
 ///     #[PrimaryKey(generation_strategy = {GenerationStrategy::AutoIncrement})]
 ///     id: i64
-///}
+/// }
 /// ```
-/// # Examples
+///
+/// # Full Examples
+///
+/// ### Basic model with field-level index
 /// ```ignore
-/// #[Model]
+/// #[derive(Model)]
 /// #[Table(name = "users")]
 /// struct User {
-///     #[Column(name= "id",unique = true,nullable = false)]
+///     #[Column(name = "id")]
 ///     #[PrimaryKey(generation_strategy = GenerationStrategy::AutoIncrement)]
-///     id: i64
-///     #[Column(name= "nm",unique = true,nullable = false)]
-///     name: String
-///}
+///     id: i64,
+///     #[Column(name = "email", unique = true, index)]
+///     email: String,
+///     #[Column(name = "username")]
+///     username: String,
+/// }
 /// ```
-#[proc_macro_derive(Model, attributes(Table, Column, PrimaryKey))]
+///
+/// ### Model with table-level composite index
+/// ```ignore
+/// #[derive(Model)]
+/// #[Table(name = "orders")]
+/// #[Index(name = "idx_user_created", fields = ["user_id", "created_at"], unique = false)]
+/// struct Order {
+///     #[Column(name = "id")]
+///     #[PrimaryKey(generation_strategy = GenerationStrategy::AutoIncrement)]
+///     id: i64,
+///     #[Column(name = "user_id")]
+///     user_id: i64,
+///     #[Column(name = "created_at")]
+///     created_at: String,
+///     #[Column(name = "amount")]
+///     amount: f64,
+/// }
+/// ```
+///
+/// ### Model with multiple indexes
+/// ```ignore
+/// #[derive(Model)]
+/// #[Table(name = "products")]
+/// #[Index(fields = ["category", "price"])]
+/// #[Index(name = "idx_unique_sku", fields = ["sku"], unique = true)]
+/// struct Product {
+///     #[Column(name = "id")]
+///     #[PrimaryKey(generation_strategy = {GenerationStrategy::AutoIncrement})]
+///     id: i64,
+///     #[Column(name = "sku", index)]
+///     sku: String,
+///     #[Column(name = "category")]
+///     category: String,
+///     #[Column(name = "price")]
+///     price: f64,
+/// }
+/// ```
+#[proc_macro_derive(Model, attributes(Table, Column, PrimaryKey, Index))]
 pub fn model_derive(input: TokenStream) -> TokenStream {
     let mut ast = parse_macro_input!(input as DeriveInput);
     let model = match parse_model(&mut ast) {

--- a/crates/corrosion-orm-macros/src/model/field.rs
+++ b/crates/corrosion-orm-macros/src/model/field.rs
@@ -2,6 +2,7 @@ use deluxe::ExtractAttributes;
 use syn::{Ident, Type};
 
 use crate::utils::is_option_type;
+
 #[derive(ExtractAttributes)]
 #[deluxe(attributes(Column))]
 pub struct ColumnAttribute {
@@ -13,7 +14,10 @@ pub struct ColumnAttribute {
     pub(crate) nullable: bool,
     #[deluxe(default = None)]
     pub(crate) column_definition: Option<String>,
+    #[deluxe(default = false)]
+    pub(crate) index: bool,
 }
+
 #[derive(Clone, Debug)]
 pub struct Field {
     #[allow(dead_code)]
@@ -24,7 +28,9 @@ pub struct Field {
     pub is_unique: bool,
     pub is_nullable: bool,
     pub column_definition: Option<String>,
+    pub has_index: bool,
 }
+
 impl From<(ColumnAttribute, &syn::Field)> for Field {
     fn from((attr, syn_field): (ColumnAttribute, &syn::Field)) -> Self {
         let field_name = if attr.name.is_empty() {
@@ -41,6 +47,7 @@ impl From<(ColumnAttribute, &syn::Field)> for Field {
             is_unique: attr.unique,
             is_nullable,
             column_definition: attr.column_definition,
+            has_index: attr.index,
         }
     }
 }

--- a/crates/corrosion-orm-macros/src/model/index.rs
+++ b/crates/corrosion-orm-macros/src/model/index.rs
@@ -1,0 +1,145 @@
+use syn::parse::{Parse, ParseStream};
+use syn::token::Comma;
+use syn::{Ident, LitBool, LitStr, Token};
+
+/// Attribute for defining indexes at the table level
+///
+/// # Examples
+/// ```ignore
+/// #[Index(name = "idx_email", fields = ["email"], unique = true)]
+/// #[Index(name = "idx_created", fields = ["created_at", "user_id"])]
+/// ```
+#[derive(Clone)]
+pub struct IndexAttribute {
+    pub(crate) name: String,
+    pub(crate) fields: Vec<String>,
+    pub(crate) unique: bool,
+}
+
+impl Parse for IndexAttribute {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut name = String::new();
+        let mut fields = Vec::new();
+        let mut unique = false;
+
+        while !input.is_empty() {
+            let key: Ident = input.parse()?;
+            input.parse::<Token![=]>()?;
+
+            if key == "name" {
+                let lit: LitStr = input.parse()?;
+                name = lit.value();
+            } else if key == "fields" {
+                let content;
+                let _bracket = syn::bracketed!(content in input);
+
+                loop {
+                    let field_lit: LitStr = content.parse()?;
+                    fields.push(field_lit.value());
+
+                    if !content.peek(Comma) {
+                        break;
+                    }
+                    content.parse::<Comma>()?;
+                }
+            } else if key == "unique" {
+                let lit: LitBool = input.parse()?;
+                unique = lit.value;
+            }
+
+            if !input.is_empty() {
+                input.parse::<Token![,]>()?;
+            }
+        }
+
+        Ok(IndexAttribute {
+            name,
+            fields,
+            unique,
+        })
+    }
+}
+
+/// Represents a parsed index definition that matches IndexModel from core
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IndexDefinition {
+    pub name: String,
+    pub fields: Vec<String>,
+    pub unique: bool,
+}
+
+impl From<IndexAttribute> for IndexDefinition {
+    fn from(attr: IndexAttribute) -> Self {
+        IndexDefinition {
+            name: attr.name,
+            fields: attr.fields,
+            unique: attr.unique,
+        }
+    }
+}
+
+impl IndexDefinition {
+    /// Create a new index definition
+    pub fn new(name: String, fields: Vec<String>, unique: bool) -> Self {
+        IndexDefinition {
+            name,
+            fields,
+            unique,
+        }
+    }
+
+    /// Generate an index name from table name and field names
+    /// Format: idx_{table}_{field1}_{field2}...
+    pub fn generate_name(table_name: &str, fields: &[String]) -> String {
+        if fields.is_empty() {
+            return format!("idx_{}", table_name);
+        }
+        let fields_str = fields.join("_");
+        format!("idx_{}_{}", table_name, fields_str)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_index_name() {
+        let name = IndexDefinition::generate_name("users", &["email".to_string()]);
+        assert_eq!(name, "idx_users_email");
+
+        let name = IndexDefinition::generate_name(
+            "users",
+            &["created_at".to_string(), "user_id".to_string()],
+        );
+        assert_eq!(name, "idx_users_created_at_user_id");
+
+        let name = IndexDefinition::generate_name("users", &[]);
+        assert_eq!(name, "idx_users");
+    }
+
+    #[test]
+    fn test_index_definition_creation() {
+        let idx = IndexDefinition::new(
+            "idx_test_email".to_string(),
+            vec!["email".to_string()],
+            true,
+        );
+        assert_eq!(idx.name, "idx_test_email");
+        assert_eq!(idx.fields, vec!["email"]);
+        assert!(idx.unique);
+    }
+
+    #[test]
+    fn test_index_definition_from_attribute() {
+        let attr = IndexAttribute {
+            name: "idx_custom".to_string(),
+            fields: vec!["field1".to_string(), "field2".to_string()],
+            unique: false,
+        };
+        let idx: IndexDefinition = attr.into();
+        assert_eq!(idx.name, "idx_custom");
+        assert_eq!(idx.fields.len(), 2);
+        assert!(!idx.unique);
+    }
+}

--- a/crates/corrosion-orm-macros/src/model/mod.rs
+++ b/crates/corrosion-orm-macros/src/model/mod.rs
@@ -1,7 +1,9 @@
 pub mod field;
+pub mod index;
 mod parser;
 pub mod primary_key;
 pub mod table;
 pub use field::{ColumnAttribute, Field};
+pub use index::{IndexAttribute, IndexDefinition};
 pub use parser::parse_model;
 pub use table::{TableAttribute, TableData};

--- a/crates/corrosion-orm-macros/src/model/parser.rs
+++ b/crates/corrosion-orm-macros/src/model/parser.rs
@@ -1,7 +1,8 @@
 use crate::model::{
-    ColumnAttribute, Field, TableAttribute, TableData,
+    ColumnAttribute, Field, IndexAttribute, IndexDefinition, TableAttribute, TableData,
     primary_key::{PrimaryKeyAttribute, PrimaryKeyField},
 };
+use std::collections::HashSet;
 use syn::{DeriveInput, Fields, spanned::Spanned};
 
 pub fn parse_model(ast: &mut DeriveInput) -> syn::Result<TableData> {
@@ -22,17 +23,63 @@ pub fn parse_model(ast: &mut DeriveInput) -> syn::Result<TableData> {
         )
     })?;
 
+    let table_name = if table_attribute.name.is_empty() {
+        ast.ident.to_string()
+    } else {
+        table_attribute.name
+    };
+
+    let table_indexes: Vec<IndexDefinition> = ast
+        .attrs
+        .iter()
+        .filter(|attr| attr.path().is_ident("Index"))
+        .filter_map(|attr| {
+            let index_attr: IndexAttribute = attr.parse_args::<IndexAttribute>().ok()?;
+            Some(IndexDefinition::from(index_attr))
+        })
+        .collect();
+
+    let mut field_indexes = Vec::new();
+    for field in &fields {
+        if field.has_index {
+            let idx_name = IndexDefinition::generate_name(&table_name, &[field.name.clone()]);
+            field_indexes.push(IndexDefinition::new(
+                idx_name,
+                vec![field.name.clone()],
+                false,
+            ));
+        }
+    }
+
+    let mut all_indexes = table_indexes;
+    all_indexes.extend(field_indexes);
+
+    let indexes = all_indexes
+        .into_iter()
+        .map(|idx| {
+            if idx.name.is_empty() {
+                IndexDefinition::new(
+                    IndexDefinition::generate_name(&table_name, &idx.fields),
+                    idx.fields,
+                    idx.unique,
+                )
+            } else {
+                idx
+            }
+        })
+        .collect::<Vec<_>>();
+
+    validate_unique_index_names(&indexes)?;
+
     syn::Result::Ok(TableData {
         ident: ast.ident.clone(),
-        name: if table_attribute.name.is_empty() {
-            ast.ident.to_string()
-        } else {
-            table_attribute.name
-        },
+        name: table_name,
         fields,
         primary_key,
+        indexes,
     })
 }
+
 fn parse_fields(fields: &mut Fields) -> syn::Result<(Vec<Field>, Option<PrimaryKeyField>)> {
     let mut fields_vec = Vec::new();
     let mut primary_key: Option<PrimaryKeyField> = None;
@@ -57,12 +104,33 @@ fn parse_fields(fields: &mut Fields) -> syn::Result<(Vec<Field>, Option<PrimaryK
     }
     Ok((fields_vec, primary_key))
 }
+
+fn validate_unique_index_names(indexes: &[IndexDefinition]) -> syn::Result<()> {
+    let mut seen_names = HashSet::new();
+
+    for idx in indexes {
+        if !seen_names.insert(&idx.name) {
+            return Err(syn::Error::new(
+                proc_macro2::Span::call_site(),
+                format!(
+                    "Duplicate index name: '{}'. Index names must be unique.",
+                    idx.name
+                ),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
 mod tests {
+    use super::*;
+    use syn::parse_quote;
+
     #[test]
     fn test_parse_model() {
-        use super::*;
-        use syn::parse_quote;
-        let input: DeriveInput = parse_quote! {
+        let mut input: DeriveInput = parse_quote! {
             #[Table(name = "users")]
             struct User {
                 #[Column(name = "id")]
@@ -75,15 +143,14 @@ mod tests {
             }
         };
 
-        let table_data = parse_model(&mut input.clone()).unwrap();
+        let table_data = parse_model(&mut input).unwrap();
         assert_eq!(table_data.name, "users");
         assert_eq!(table_data.fields[0].name, "username");
         assert_eq!(table_data.primary_key.name, "id");
     }
+
     #[test]
     fn fail_multiple_primary_keys() {
-        use super::*;
-        use syn::parse_quote;
         let mut input: DeriveInput = parse_quote! {
             #[Table(name = "users")]
             struct User {
@@ -104,10 +171,9 @@ mod tests {
             "Only one field can be marked with #[PrimaryKey]"
         );
     }
+
     #[test]
     fn fail_missing_primary_key() {
-        use super::*;
-        use syn::parse_quote;
         let mut input: DeriveInput = parse_quote! {
             #[Table(name = "users")]
             struct User {
@@ -126,11 +192,10 @@ mod tests {
             "A Model must have exactly one field marked with #[PrimaryKey]"
         );
     }
+
     #[test]
     fn primary_key_with_generation_strategy() {
-        use super::*;
         use corrosion_orm_core::types::generation_strategy::GenerationType;
-        use syn::parse_quote;
         let mut input: DeriveInput = parse_quote! {
             #[Table(name = "users")]
             struct User {
@@ -149,17 +214,16 @@ mod tests {
             GenerationType::AutoIncrement
         );
     }
+
     #[test]
     fn test_column_definition() {
-        use super::*;
-        use syn::parse_quote;
         let mut input: DeriveInput = parse_quote! {
             #[Table(name = "users")]
             struct User {
                 #[Column(name = "id")]
                 #[PrimaryKey]
                 id: i32,
-                #[Column(name = "username", column_definition = "INTEGER",unique)]
+                #[Column(name = "username", column_definition = "INTEGER", unique)]
                 username: String,
                 #[Column(name = "email", unique = false, nullable)]
                 email: Option<String>,
@@ -170,5 +234,115 @@ mod tests {
             table_data.fields[0].column_definition,
             Some(String::from("INTEGER"))
         );
+    }
+
+    #[test]
+    fn test_field_level_index() {
+        let mut input: DeriveInput = parse_quote! {
+            #[Table(name = "users")]
+            struct User {
+                #[Column(name = "id")]
+                #[PrimaryKey]
+                id: i32,
+                #[Column(name = "email", index)]
+                email: String,
+            }
+        };
+        let table_data = parse_model(&mut input).unwrap();
+        assert_eq!(table_data.indexes.len(), 1);
+        assert_eq!(table_data.indexes[0].fields, vec!["email"]);
+        assert_eq!(table_data.indexes[0].name, "idx_users_email");
+    }
+
+    #[test]
+    fn test_table_level_index() {
+        let mut input: DeriveInput = parse_quote! {
+            #[Table(name = "users")]
+            #[Index(name = "idx_email", fields = ["email"], unique = true)]
+            struct User {
+                #[Column(name = "id")]
+                #[PrimaryKey]
+                id: i32,
+                #[Column(name = "email")]
+                email: String,
+            }
+        };
+        let table_data = parse_model(&mut input).unwrap();
+        assert_eq!(table_data.indexes.len(), 1);
+        assert_eq!(table_data.indexes[0].name, "idx_email");
+        assert!(table_data.indexes[0].unique);
+    }
+
+    #[test]
+    fn test_auto_generate_index_name() {
+        let mut input: DeriveInput = parse_quote! {
+            #[Table(name = "users")]
+            #[Index(fields = ["email", "created_at"])]
+            struct User {
+                #[Column(name = "id")]
+                #[PrimaryKey]
+                id: i32,
+                #[Column(name = "email")]
+                email: String,
+                #[Column(name = "created_at")]
+                created_at: String,
+            }
+        };
+        let table_data = parse_model(&mut input).unwrap();
+        assert_eq!(table_data.indexes.len(), 1);
+        assert_eq!(table_data.indexes[0].name, "idx_users_email_created_at");
+    }
+
+    #[test]
+    fn test_duplicate_index_names() {
+        let mut input: DeriveInput = parse_quote! {
+            #[Table(name = "users")]
+            #[Index(name = "idx_email", fields = ["email"])]
+            #[Index(name = "idx_email", fields = ["username"])]
+            struct User {
+                #[Column(name = "id")]
+                #[PrimaryKey]
+                id: i32,
+                #[Column(name = "email")]
+                email: String,
+            }
+        };
+        let result = parse_model(&mut input);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Duplicate index name")
+        );
+    }
+
+    #[test]
+    fn test_mixed_field_and_table_indexes() {
+        let mut input: DeriveInput = parse_quote! {
+            #[Table(name = "users")]
+            #[Index(name = "idx_composite", fields = ["email", "username"], unique = true)]
+            struct User {
+                #[Column(name = "id")]
+                #[PrimaryKey]
+                id: i32,
+                #[Column(name = "email", index)]
+                email: String,
+                #[Column(name = "username")]
+                username: String,
+            }
+        };
+        let table_data = parse_model(&mut input).unwrap();
+        assert_eq!(table_data.indexes.len(), 2);
+        let has_composite = table_data
+            .indexes
+            .iter()
+            .any(|idx| idx.name == "idx_composite");
+        let has_email = table_data
+            .indexes
+            .iter()
+            .any(|idx| idx.name == "idx_users_email");
+        assert!(has_composite);
+        assert!(has_email);
     }
 }

--- a/crates/corrosion-orm-macros/src/model/parser.rs
+++ b/crates/corrosion-orm-macros/src/model/parser.rs
@@ -42,7 +42,8 @@ pub fn parse_model(ast: &mut DeriveInput) -> syn::Result<TableData> {
     let mut field_indexes = Vec::new();
     for field in &fields {
         if field.has_index {
-            let idx_name = IndexDefinition::generate_name(&table_name, &[field.name.clone()]);
+            let idx_name =
+                IndexDefinition::generate_name(&table_name, std::slice::from_ref(&field.name));
             field_indexes.push(IndexDefinition::new(
                 idx_name,
                 vec![field.name.clone()],

--- a/crates/corrosion-orm-macros/src/model/table.rs
+++ b/crates/corrosion-orm-macros/src/model/table.rs
@@ -1,6 +1,6 @@
 use deluxe::ExtractAttributes;
 
-use crate::model::{Field, primary_key::PrimaryKeyField};
+use crate::model::{Field, IndexDefinition, primary_key::PrimaryKeyField};
 
 #[derive(ExtractAttributes)]
 #[deluxe(attributes(Table))]
@@ -8,10 +8,12 @@ pub struct TableAttribute {
     #[deluxe(default = String::from(""))]
     pub(crate) name: String,
 }
+
 #[derive(Debug)]
 pub struct TableData {
     pub ident: syn::Ident,
     pub name: String,
     pub fields: Vec<Field>,
     pub primary_key: PrimaryKeyField,
+    pub indexes: Vec<IndexDefinition>,
 }

--- a/crates/corrosion-orm-test/src/dialect/snapshots/corrosion_orm_test__dialect__tests__generate_ddl_sqlite.snap
+++ b/crates/corrosion-orm-test/src/dialect/snapshots/corrosion_orm_test__dialect__tests__generate_ddl_sqlite.snap
@@ -6,3 +6,4 @@ CREATE TABLE users (
     id INTEGER PRIMARY KEY,
     name TEXT NULL UNIQUE
 );
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_id ON users (id);

--- a/crates/corrosion-orm-test/src/test_entities.rs
+++ b/crates/corrosion-orm-test/src/test_entities.rs
@@ -13,6 +13,7 @@ impl SqlDialect for MockSqliteDialect {
 }
 #[derive(Model, Clone, Debug)]
 #[Table(name = "users")]
+#[Index(name = "idx_users_id", fields = ["id"], unique = true)]
 pub struct User {
     #[Column(name = "id")]
     #[PrimaryKey]


### PR DESCRIPTION
This pull request adds comprehensive support for table and column indexes in the ORM derive macros, allowing users to define both single-column and multi-column (composite) indexes directly in their Rust models. It introduces new attributes and parsing logic for indexes, generates the necessary schema metadata, and updates documentation and code generation accordingly.

**Index support and schema generation:**

* Added a new `#[Index]` attribute for table-level composite indexes, and an `index` flag for column-level single-field indexes. These are parsed and collected into the schema metadata. [[1]](diffhunk://#diff-db2dd20b294967d848cf7f72e6a153e5be17d37bfc2e1c3b156af376d430ac68R1-R145) [[2]](diffhunk://#diff-67acd52ecc43ca5ffee8f83fe3ddc268a297371e9f77e66708cbfe87f3274189R17-R20) [[3]](diffhunk://#diff-67acd52ecc43ca5ffee8f83fe3ddc268a297371e9f77e66708cbfe87f3274189R31-R33) [[4]](diffhunk://#diff-67acd52ecc43ca5ffee8f83fe3ddc268a297371e9f77e66708cbfe87f3274189R50) [[5]](diffhunk://#diff-4d78ed30b474e490dfe2c71629269ecf3516c7782f4bd11c6407cb20dd3869efL2-R5) [[6]](diffhunk://#diff-4d78ed30b474e490dfe2c71629269ecf3516c7782f4bd11c6407cb20dd3869efL25-R82)
* Ensured that all index names are unique within a table, with validation to catch duplicates at compile time. [[1]](diffhunk://#diff-4d78ed30b474e490dfe2c71629269ecf3516c7782f4bd11c6407cb20dd3869efL25-R82) [[2]](diffhunk://#diff-4d78ed30b474e490dfe2c71629269ecf3516c7782f4bd11c6407cb20dd3869efR107-R133)

**Macro code generation and schema model:**

* Updated code generation to include all parsed indexes in the generated `TableSchemaModel`, and to generate code for index metadata. [[1]](diffhunk://#diff-1d5c8e286943552a25f3b08a5e82d165ec54330286eccb1870b7589cfd00eefdR14-R18) [[2]](diffhunk://#diff-1d5c8e286943552a25f3b08a5e82d165ec54330286eccb1870b7589cfd00eefdL28-R40) [[3]](diffhunk://#diff-1d5c8e286943552a25f3b08a5e82d165ec54330286eccb1870b7589cfd00eefdR65-R79)
* Added a new `IndexDefinition` type to represent indexes in the schema and provide utility methods for name generation.

**SQL DDL generation:**

* Modified the SQL dialect trait to emit `CREATE INDEX` statements for all defined indexes when generating table DDL.

**Documentation and usability:**

* Expanded and clarified documentation with detailed examples for table and field indexes, composite indexes, and usage of the new attributes.

**Internal refactoring and tests:**

* Refactored model parsing to support new index features and added thorough unit tests for index parsing, uniqueness, and schema model correctness. [[1]](diffhunk://#diff-4d78ed30b474e490dfe2c71629269ecf3516c7782f4bd11c6407cb20dd3869efL78-L86) [[2]](diffhunk://#diff-4d78ed30b474e490dfe2c71629269ecf3516c7782f4bd11c6407cb20dd3869efR174-L110) [[3]](diffhunk://#diff-4d78ed30b474e490dfe2c71629269ecf3516c7782f4bd11c6407cb20dd3869efR195-L133) [[4]](diffhunk://#diff-4d78ed30b474e490dfe2c71629269ecf3516c7782f4bd11c6407cb20dd3869efR217-L155)

These changes provide a robust, extensible foundation for index support in the ORM derive macros, improving both schema expressiveness and generated SQL.