### PR TITLE
feat: Ordering in SELECT queries

### DIFF
--- a/crates/corrosion-orm-core/src/model/finder.rs
+++ b/crates/corrosion-orm-core/src/model/finder.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 use crate::{
     CorrosionOrmError, Executor,
     prelude::QueryContext,
-    query::{Select, ToSql, WhereClause},
+    query::{Select, ToSql, WhereClause, order_by::OrderBy},
     types::ColumnTrait,
 };
 
@@ -46,6 +46,15 @@ where
     pub fn filter(self, filter: WhereClause<C>) -> Self {
         Self {
             query: self.query.where_clause(filter),
+            _entity: PhantomData,
+            _executor: PhantomData,
+        }
+    }
+    /// Adds an order to order clause in the query.
+    ///
+    pub fn add_order_by(self, order_by: OrderBy<C>) -> Self {
+        Self {
+            query: self.query.add_order_by(order_by),
             _entity: PhantomData,
             _executor: PhantomData,
         }

--- a/crates/corrosion-orm-core/src/query/mod.rs
+++ b/crates/corrosion-orm-core/src/query/mod.rs
@@ -55,6 +55,7 @@
 
 pub mod delete;
 pub mod insert;
+pub mod order_by;
 pub mod query_type;
 pub mod select;
 pub mod to_sql;

--- a/crates/corrosion-orm-core/src/query/order_by.rs
+++ b/crates/corrosion-orm-core/src/query/order_by.rs
@@ -1,0 +1,52 @@
+use crate::{
+    dialect::sql_dialect::SqlDialect, prelude::QueryContext, query::ToSql,
+    types::column_trait::ColumnTrait,
+};
+
+#[derive(Debug, Clone)]
+pub struct OrderClause<C: ColumnTrait> {
+    pub columns: Vec<OrderBy<C>>,
+}
+
+impl<C: ColumnTrait> OrderClause<C> {
+    pub fn new(columns: Vec<OrderBy<C>>) -> Self {
+        Self { columns }
+    }
+}
+
+impl<C: ColumnTrait> ToSql for OrderClause<C> {
+    fn to_sql(&self, ctx: &mut QueryContext, _dialect: &dyn SqlDialect) {
+        for (i, order) in self.columns.iter().enumerate() {
+            if i > 0 {
+                ctx.sql.push_str(", ");
+            }
+            order.to_sql(ctx, _dialect);
+        }
+    }
+}
+#[derive(Debug, Clone)]
+pub struct OrderBy<C: ColumnTrait> {
+    pub column: C,
+    pub direction: OrderDirection,
+}
+#[derive(Debug, Clone)]
+pub enum OrderDirection {
+    Asc,
+    Desc,
+}
+
+impl<C: ColumnTrait> OrderBy<C> {
+    pub fn new(column: C, direction: OrderDirection) -> Self {
+        Self { column, direction }
+    }
+}
+
+impl<C: ColumnTrait> ToSql for OrderBy<C> {
+    fn to_sql(&self, ctx: &mut QueryContext, _dialect: &dyn SqlDialect) {
+        ctx.sql.push_str(self.column.as_str());
+        match self.direction {
+            OrderDirection::Asc => ctx.sql.push_str(" ASC"),
+            OrderDirection::Desc => ctx.sql.push_str(" DESC"),
+        }
+    }
+}

--- a/crates/corrosion-orm-core/src/query/select.rs
+++ b/crates/corrosion-orm-core/src/query/select.rs
@@ -1,7 +1,12 @@
 use std::borrow::Cow;
 
 use crate::{
-    dialect::sql_dialect::SqlDialect, query::to_sql::ToSql, schema::table::TableSchemaModel,
+    dialect::sql_dialect::SqlDialect,
+    query::{
+        order_by::{OrderBy, OrderClause},
+        to_sql::ToSql,
+    },
+    schema::table::TableSchemaModel,
     types::ColumnTrait,
 };
 
@@ -41,6 +46,7 @@ pub struct Select<'query, C: ColumnTrait> {
     columns: Vec<Cow<'query, str>>,
     where_clause: Option<WhereClause<C>>,
     limit: Option<usize>,
+    order_by: Option<OrderClause<C>>,
 }
 
 impl<'col, C: ColumnTrait> Select<'col, C> {
@@ -49,6 +55,7 @@ impl<'col, C: ColumnTrait> Select<'col, C> {
             table: table.into(),
             columns: Vec::new(),
             where_clause: None,
+            order_by: None,
             limit: None,
         }
     }
@@ -68,6 +75,17 @@ impl<'col, C: ColumnTrait> Select<'col, C> {
         self.where_clause = Some(where_clause);
         self
     }
+    pub fn add_order_by(mut self, order_by: OrderBy<C>) -> Self {
+        if let Some(order_clause) = &mut self.order_by {
+            order_clause.columns.push(order_by);
+        } else {
+            self.order_by = Some(OrderClause {
+                columns: vec![order_by],
+            });
+        }
+        self
+    }
+
     #[cfg(feature = "test-utils")]
     pub fn get_table(&self) -> &str {
         &self.table
@@ -100,6 +118,10 @@ impl<C: ColumnTrait> ToSql for Select<'_, C> {
             ctx.sql.push_str(" WHERE ");
             where_clause.to_sql(ctx, _dialect);
         }
+        if let Some(order_by) = &self.order_by {
+            ctx.sql.push_str(" ORDER BY ");
+            order_by.to_sql(ctx, _dialect);
+        }
         if let Some(limit) = self.limit {
             ctx.sql.push_str(&format!(" LIMIT {}", limit));
         }
@@ -115,6 +137,7 @@ impl<'col, C: ColumnTrait> From<&'col TableSchemaModel> for Select<'col, C> {
                 .map(Cow::Borrowed)
                 .collect(),
             where_clause: None,
+            order_by: None,
             limit: None,
         }
     }
@@ -133,6 +156,7 @@ impl<'col, C: ColumnTrait> From<TableSchemaModel> for Select<'col, C> {
             table: Cow::Owned(schema.name),
             columns,
             where_clause: None,
+            order_by: None,
             limit: None,
         }
     }

--- a/crates/corrosion-orm-core/src/types/column.rs
+++ b/crates/corrosion-orm-core/src/types/column.rs
@@ -2,30 +2,47 @@
 
 use crate::{
     query::{
+        order_by::{OrderBy, OrderDirection},
         query_type::Value,
         where_clause::{Condition, WhereClause, WhereClauseType},
     },
     types::ColumnTrait,
 };
+macro_rules! create_boller_plate {
+    ($name:ident) => {
+        impl<C: ColumnTrait> $name<C> {
+            pub fn asc(&self) -> OrderBy<C> {
+                OrderBy::new(self.column.clone(), OrderDirection::Asc)
+            }
+            pub fn desc(&self) -> OrderBy<C> {
+                OrderBy::new(self.column.clone(), OrderDirection::Desc)
+            }
+            /// Creates a `WhereClause` for equality comparison with a value.
+            pub fn eq<V: Into<Value>>(self, val: V) -> WhereClause<C> {
+                WhereClause::eq(self.column, val)
+            }
+            /// Creates a `WhereClause` for inequality comparison with a value.
+            pub fn ne<V: Into<Value>>(self, val: V) -> WhereClause<C> {
+                WhereClause::ne(self.column, val)
+            }
+            /// Creates a `WhereClause` for `IS NULL` comparison.
+            pub fn is_null(self) -> WhereClause<C> {
+                WhereClause::is_null(self.column)
+            }
+        }
+    };
+}
 
 /// A string column wrapper with methods for string-specific operations.
 pub struct StringColumn<C: ColumnTrait> {
     pub column: C,
 }
-
+create_boller_plate!(StringColumn);
 impl<C: ColumnTrait> StringColumn<C> {
     pub const fn new(column: C) -> Self {
         Self { column }
     }
-    /// Creates a `WhereClause` for equality comparison with a value.
-    pub fn eq<V: Into<Value>>(self, val: V) -> WhereClause<C> {
-        WhereClause::eq(self.column, val)
-    }
 
-    /// Creates a `WhereClause` for inequality comparison with a value.
-    pub fn ne<V: Into<Value>>(self, val: V) -> WhereClause<C> {
-        WhereClause::ne(self.column, val)
-    }
     /// Creates a `WhereClause` for `LIKE` comparison with a value.
     pub fn like<V: Into<Value>>(self, val: V) -> WhereClause<C> {
         WhereClause::new(WhereClauseType::Condition(Condition::like(
@@ -78,28 +95,16 @@ impl<C: ColumnTrait> StringColumn<C> {
         let values: Vec<Value> = vals.into_iter().map(|v| v.into()).collect();
         WhereClause::in_(self.column, values)
     }
-    /// Creates a `WhereClause` for `IS NULL` comparison.
-    pub fn is_null(self) -> WhereClause<C> {
-        WhereClause::is_null(self.column)
-    }
 }
 
 /// A numeric column wrapper with methods for numeric-specific operations.
 pub struct NumericColumn<C: ColumnTrait> {
     pub column: C,
 }
-
+create_boller_plate!(NumericColumn);
 impl<C: ColumnTrait> NumericColumn<C> {
     pub const fn new(column: C) -> Self {
         Self { column }
-    }
-    /// Creates a `WhereClause` for equality comparison with a value.
-    pub fn eq<V: Into<Value>>(self, val: V) -> WhereClause<C> {
-        WhereClause::eq(self.column, val)
-    }
-    /// Creates a `WhereClause` for inequality comparison with a value.
-    pub fn ne<V: Into<Value>>(self, val: V) -> WhereClause<C> {
-        WhereClause::ne(self.column, val)
     }
     /// Creates a `WhereClause` for greater-than comparison with a value.
     pub fn gt<V: Into<Value>>(self, val: V) -> WhereClause<C> {
@@ -130,28 +135,16 @@ impl<C: ColumnTrait> NumericColumn<C> {
         let values: Vec<Value> = vals.into_iter().map(|v| v.into()).collect();
         WhereClause::in_(self.column, values)
     }
-
-    pub fn is_null(self) -> WhereClause<C> {
-        WhereClause::is_null(self.column)
-    }
 }
 
 /// A date/timestamp column wrapper with methods for date-specific operations.
 pub struct DateLikeColumn<C: ColumnTrait> {
     column: C,
 }
-
+create_boller_plate!(DateLikeColumn);
 impl<C: ColumnTrait> DateLikeColumn<C> {
     pub const fn new(column: C) -> Self {
         Self { column }
-    }
-
-    pub fn eq<V: Into<Value>>(self, val: V) -> WhereClause<C> {
-        WhereClause::eq(self.column, val)
-    }
-
-    pub fn ne<V: Into<Value>>(self, val: V) -> WhereClause<C> {
-        WhereClause::ne(self.column, val)
     }
 
     pub fn gt<V: Into<Value>>(self, val: V) -> WhereClause<C> {
@@ -177,31 +170,15 @@ impl<C: ColumnTrait> DateLikeColumn<C> {
             max,
         )))
     }
-
-    pub fn is_null(self) -> WhereClause<C> {
-        WhereClause::is_null(self.column)
-    }
 }
 
 /// A boolean column wrapper with methods for boolean-specific operations.
 pub struct BooleanColumn<C: ColumnTrait> {
     column: C,
 }
-
+create_boller_plate!(BooleanColumn);
 impl<C: ColumnTrait> BooleanColumn<C> {
     pub const fn new(column: C) -> Self {
         Self { column }
-    }
-
-    pub fn eq<V: Into<Value>>(self, val: V) -> WhereClause<C> {
-        WhereClause::eq(self.column, val)
-    }
-
-    pub fn ne<V: Into<Value>>(self, val: V) -> WhereClause<C> {
-        WhereClause::ne(self.column, val)
-    }
-
-    pub fn is_null(self) -> WhereClause<C> {
-        WhereClause::is_null(self.column)
     }
 }

--- a/crates/corrosion-orm-core/src/types/column.rs
+++ b/crates/corrosion-orm-core/src/types/column.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     types::ColumnTrait,
 };
-macro_rules! create_boller_plate {
+macro_rules! create_boiler_plate {
     ($name:ident) => {
         impl<C: ColumnTrait> $name<C> {
             pub fn asc(&self) -> OrderBy<C> {
@@ -37,7 +37,7 @@ macro_rules! create_boller_plate {
 pub struct StringColumn<C: ColumnTrait> {
     pub column: C,
 }
-create_boller_plate!(StringColumn);
+create_boiler_plate!(StringColumn);
 impl<C: ColumnTrait> StringColumn<C> {
     pub const fn new(column: C) -> Self {
         Self { column }
@@ -101,7 +101,7 @@ impl<C: ColumnTrait> StringColumn<C> {
 pub struct NumericColumn<C: ColumnTrait> {
     pub column: C,
 }
-create_boller_plate!(NumericColumn);
+create_boiler_plate!(NumericColumn);
 impl<C: ColumnTrait> NumericColumn<C> {
     pub const fn new(column: C) -> Self {
         Self { column }
@@ -141,7 +141,7 @@ impl<C: ColumnTrait> NumericColumn<C> {
 pub struct DateLikeColumn<C: ColumnTrait> {
     column: C,
 }
-create_boller_plate!(DateLikeColumn);
+create_boiler_plate!(DateLikeColumn);
 impl<C: ColumnTrait> DateLikeColumn<C> {
     pub const fn new(column: C) -> Self {
         Self { column }
@@ -176,7 +176,7 @@ impl<C: ColumnTrait> DateLikeColumn<C> {
 pub struct BooleanColumn<C: ColumnTrait> {
     column: C,
 }
-create_boller_plate!(BooleanColumn);
+create_boiler_plate!(BooleanColumn);
 impl<C: ColumnTrait> BooleanColumn<C> {
     pub const fn new(column: C) -> Self {
         Self { column }

--- a/crates/corrosion-orm-test/src/query/select_tests.rs
+++ b/crates/corrosion-orm-test/src/query/select_tests.rs
@@ -2,6 +2,7 @@
 mod tests {
     use crate::User;
     use corrosion_orm_core::dialect::sqlite_dialect::sqlite::SqliteDialect;
+    use corrosion_orm_core::query::order_by::{OrderBy, OrderDirection};
     use corrosion_orm_core::query::query_type::{QueryContext, Value};
     use corrosion_orm_core::query::select::Select;
     use corrosion_orm_core::query::to_sql::ToSql;
@@ -191,5 +192,23 @@ mod tests {
             .limit(20);
         let sql = render_select(select);
         insta::assert_snapshot!(sql, @"SELECT name, role FROM users WHERE (role = ? OR role = ?) AND experience > ? LIMIT 20");
+    }
+    #[test]
+    fn test_select_with_order_by_asc() {
+        let select = Select::new("users")
+            .add_column("name")
+            .add_column("role")
+            .add_order_by(OrderBy::new(Col("name"), OrderDirection::Asc));
+        let sql = render_select(select);
+        insta::assert_snapshot!(sql, @"SELECT name, role FROM users ORDER BY name ASC");
+    }
+    #[test]
+    fn test_select_with_order_by_desc() {
+        let select = Select::new("users")
+            .add_column("name")
+            .add_column("role")
+            .add_order_by(OrderBy::new(Col("name"), OrderDirection::Desc));
+        let sql = render_select(select);
+        insta::assert_snapshot!(sql, @"SELECT name, role FROM users ORDER BY name DESC");
     }
 }

--- a/crates/corrosion-orm-test/src/repository_test/find_test.rs
+++ b/crates/corrosion-orm-test/src/repository_test/find_test.rs
@@ -4,7 +4,7 @@ mod tests {
     use corrosion_orm_core::prelude::*;
     const USER_COUNT: usize = 5;
     async fn init_users(conn: &mut impl Executor, n: usize) -> Result<(), CorrosionOrmError> {
-        for i in 0..n {
+        for i in 1..n + 1 {
             let user = User {
                 id: i as i32,
                 name: format!("user{}", i),
@@ -88,6 +88,30 @@ mod tests {
         init_users(&mut conn, USER_COUNT).await?;
         let users = User::find().limit(2).all(&mut conn).await?;
         assert_eq!(users.len(), 2);
+        Ok(())
+    }
+    #[tokio::test]
+    async fn test_find_order_by_asc() -> Result<(), CorrosionOrmError> {
+        let db = init_sqlite().await;
+        let mut conn = db.acquire_conn().await.unwrap();
+        init_users(&mut conn, USER_COUNT).await?;
+        let users = User::find()
+            .add_order_by(user::COLUMN.id.asc())
+            .all(&mut conn)
+            .await?;
+        assert_eq!(users.first().unwrap().id, 1);
+        Ok(())
+    }
+    #[tokio::test]
+    async fn test_find_order_by_desc() -> Result<(), CorrosionOrmError> {
+        let db = init_sqlite().await;
+        let mut conn = db.acquire_conn().await.unwrap();
+        init_users(&mut conn, USER_COUNT).await?;
+        let users = User::find()
+            .add_order_by(user::COLUMN.id.desc())
+            .all(&mut conn)
+            .await?;
+        assert_eq!(users.first().unwrap().id, USER_COUNT as i32);
         Ok(())
     }
 }


### PR DESCRIPTION
This pull request adds support for SQL `ORDER BY` clauses to the query builder in the ORM, enabling users to specify sorting directions (ascending or descending) when querying data. It introduces new types for representing orderings, updates the query construction logic, and adds corresponding tests to ensure correct SQL generation and integration with the finder API. Additionally, it refactors column wrapper code to reduce duplication by introducing a macro for common methods.

**ORDER BY clause support:**

* Added new `OrderBy`, `OrderDirection`, and `OrderClause` types in `order_by.rs` to represent and build SQL `ORDER BY` clauses. These types implement the `ToSql` trait for SQL generation.
* Updated the `Select` query builder to support adding and serializing `ORDER BY` clauses via a new `add_order_by` method and an `order_by` field. [[1]](diffhunk://#diff-7bcd566a02501b4b8356370919977f43212dd1b0fd9d5bed310fca792dd935e1R49) [[2]](diffhunk://#diff-7bcd566a02501b4b8356370919977f43212dd1b0fd9d5bed310fca792dd935e1R58) [[3]](diffhunk://#diff-7bcd566a02501b4b8356370919977f43212dd1b0fd9d5bed310fca792dd935e1R78-R88) [[4]](diffhunk://#diff-7bcd566a02501b4b8356370919977f43212dd1b0fd9d5bed310fca792dd935e1R121-R124) [[5]](diffhunk://#diff-7bcd566a02501b4b8356370919977f43212dd1b0fd9d5bed310fca792dd935e1R140) [[6]](diffhunk://#diff-7bcd566a02501b4b8356370919977f43212dd1b0fd9d5bed310fca792dd935e1R159)
* Exposed the `add_order_by` method on the finder API, allowing users to specify ordering when building queries. [[1]](diffhunk://#diff-ef61c969e661078199791c9a2b28dd3bf535428a64e8dbc77d6188a62ea1a153L7-R7) [[2]](diffhunk://#diff-ef61c969e661078199791c9a2b28dd3bf535428a64e8dbc77d6188a62ea1a153R53-R61)

**Column wrapper refactor:**

* Introduced the `create_boller_plate!` macro to generate common methods (`asc`, `desc`, `eq`, `ne`, `is_null`) for column wrapper types, reducing code duplication across `StringColumn`, `NumericColumn`, `DateLikeColumn`, and `BooleanColumn`. [[1]](diffhunk://#diff-749aaf991c2744e3eccb294f47f6a89d9d802c4419e24d194c75335afaa50d7eR5-R45) [[2]](diffhunk://#diff-749aaf991c2744e3eccb294f47f6a89d9d802c4419e24d194c75335afaa50d7eL81-L103) [[3]](diffhunk://#diff-749aaf991c2744e3eccb294f47f6a89d9d802c4419e24d194c75335afaa50d7eL133-L156) [[4]](diffhunk://#diff-749aaf991c2744e3eccb294f47f6a89d9d802c4419e24d194c75335afaa50d7eL180-L206)

**Testing and validation:**

* Added unit tests for `ORDER BY` clause generation in both the core query builder and the repository finder API, verifying correct SQL output for ascending and descending orders. [[1]](diffhunk://#diff-8d1244cff63ce12b52900b4c7b08ec4f7a410b7ae014581eb3da279c66e675e6R5) [[2]](diffhunk://#diff-8d1244cff63ce12b52900b4c7b08ec4f7a410b7ae014581eb3da279c66e675e6R196-R213) [[3]](diffhunk://#diff-3ad0fe9859f853d0bd70fa3f35ea42bcc8211036c3535238fda3761c822e1284R93-R116)

**Miscellaneous:**

* Fixed the user initialization loop in test setup to start from 1, ensuring user IDs align with test expectations.