### PR TITLE
Feat/pagination

### DIFF
--- a/crates/corrosion-orm-core/src/lib.rs
+++ b/crates/corrosion-orm-core/src/lib.rs
@@ -27,6 +27,7 @@ pub mod prelude {
     pub use crate::driver::transaction::Transaction;
     pub use crate::error::CorrosionOrmError;
     pub use crate::model::repository::Repo;
+    pub use crate::model::{CursorPaginator, Paginator};
     pub use crate::query::*;
     pub use crate::query::{
         Delete, Insert, Select, Update,

--- a/crates/corrosion-orm-core/src/model/cursor_paginator.rs
+++ b/crates/corrosion-orm-core/src/model/cursor_paginator.rs
@@ -1,0 +1,119 @@
+//! Cursor-based pagination for database queries.
+//!
+//! This module provides the [`CursorPaginator`] struct, which implements efficient
+//! cursor-based pagination using keyset pagination (also known as "seek-method" or
+//! "keyset filtering"). This pagination strategy is ideal for high-performance APIs
+//! and datasets that change frequently.
+//!
+//! # Understanding Cursor-Based Pagination
+//!
+//! Unlike offset-based pagination that uses `OFFSET` to skip rows, cursor-based
+//! pagination uses the values of the last row to seek to the next set of records.
+//! This approach offers several advantages:
+//! - **Consistent O(1) performance** - Each page takes the same time to fetch
+//! - **Handles real-time updates** - New/deleted rows don't cause pagination inconsistencies
+//! - **Scalability** - Works efficiently with large datasets and deep pagination
+//!
+//! # When to Use Cursor-Based Pagination
+//!
+//! Cursor-based pagination with [`CursorPaginator`] is best suited for:
+//! - **Large result sets** (100K+ rows)
+//! - **High-performance APIs** requiring consistent response times
+//! - **Real-time data** that changes during pagination
+//! - **Deep pagination** (fetching page 1000+)
+//! - **Infinite scroll patterns** in web/mobile applications
+//! - **Streaming scenarios** where rows are continuously added
+//!
+//! # When NOT to Use Cursor-Based Pagination
+//!
+//! Cursor-based pagination is **not ideal** for:
+//! - **Jumping to arbitrary pages** (you must paginate sequentially)
+//! - **Small datasets** where simpler offset pagination is sufficient
+//! - **User interfaces** requiring page numbers (1, 2, 3, etc.)
+//! - **Accessing pages in random order**
+//!
+//! In these cases, consider using [`crate::model::Paginator`] instead.
+//!
+//! # Sort and Unique Columns
+//!
+//! Cursor pagination requires two columns:
+//!
+//! 1. **Sort Column** - The column used to order results. Can be non-unique.
+//!    - Examples: `created_at`, `score`, `priority`
+//!    - Used to determine result ordering
+//!
+//! 2. **Unique Column** - A column that uniquely identifies each row.
+//!    - Examples: `id`, `uuid`
+//!    - Must be unique and immutable
+//!    - Used to break ties when sort column values are equal
+//!    - Ensures reproducible pagination even with duplicate sort values
+//!
+//! Together, these columns form a composite sort key that:
+//! - Uniquely identifies each row: `(sort_col, unique_col)`
+//! - Ensures pagination doesn't skip or repeat rows
+//! - Allows efficient index-based seeking
+//!
+//! # Performance Notes
+//!
+//! Cursor pagination typically delivers:
+//! - **Constant time per page** regardless of total dataset size
+//! - **Efficient database index usage** with proper column indexing
+//! - **Reduced memory overhead** compared to offset-based approaches
+//!
+//! For optimal performance:
+//! - Index the sort column: `CREATE INDEX idx_col_sorted ON table(sort_col, unique_col)`
+//! - Use immutable unique columns (typically auto-increment IDs)
+
+use crate::{
+    CorrosionOrmError, Executor, model::Finder, prelude::Value, query::WhereClause,
+    types::ColumnTrait,
+};
+
+pub struct CursorPaginator<'query, T, E: Executor, C: ColumnTrait> {
+    finder: Finder<'query, T, E, C>,
+    page_size: usize,
+    last_row: Option<T>,
+}
+
+impl<'query, T, E: Executor, C: ColumnTrait> CursorPaginator<'query, T, E, C>
+where
+    T: Send + Unpin + Clone + for<'r> sqlx::FromRow<'r, sqlx::sqlite::SqliteRow>,
+{
+    pub fn new(finder: Finder<'query, T, E, C>, page_size: usize) -> Self {
+        Self {
+            finder,
+            page_size,
+            last_row: None,
+        }
+    }
+
+    /// Fetches the next page based on the last row retrieved.
+    pub async fn fetch_next(
+        &mut self,
+        db: &mut E,
+        get_sort_val: impl Fn(&T) -> Value,
+        get_unique_val: impl Fn(&T) -> Value,
+        sort_col: C,
+        unique_col: C,
+    ) -> Result<Option<Vec<T>>, CorrosionOrmError> {
+        let mut query = self.finder.clone().limit(self.page_size);
+
+        if let Some(last) = &self.last_row {
+            let sort_val = get_sort_val(last);
+            let unique_val = get_unique_val(last);
+
+            query = query.filter(WhereClause::seek_after(
+                sort_col, sort_val, unique_col, unique_val,
+            ));
+        }
+
+        let results = query.all(db).await?;
+
+        if results.is_empty() {
+            Ok(None)
+        } else {
+            self.last_row = results.last().cloned();
+            Ok(Some(results))
+        }
+    }
+}

--- a/crates/corrosion-orm-core/src/model/finder.rs
+++ b/crates/corrosion-orm-core/src/model/finder.rs
@@ -3,12 +3,12 @@ use std::marker::PhantomData;
 
 use crate::{
     CorrosionOrmError, Executor,
+    model::paginator::Paginator,
     prelude::QueryContext,
     query::{Select, ToSql, WhereClause, order_by::OrderBy},
     types::ColumnTrait,
 };
 
-#[derive(Clone)]
 /// Query result set from a database query for find() method.
 ///
 /// This struct is now generic over C: ColumnTrait to ensure model-level type safety.
@@ -17,7 +17,18 @@ pub struct Finder<'query, T, E: Executor, C: ColumnTrait> {
     _entity: PhantomData<T>,
     _executor: PhantomData<E>,
 }
-
+impl<'query, T, E: Executor, C: ColumnTrait> Clone for Finder<'query, T, E, C>
+where
+    Select<'query, C>: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            query: self.query.clone(),
+            _entity: PhantomData,
+            _executor: PhantomData,
+        }
+    }
+}
 impl<'query, T, E: Executor, C: ColumnTrait> Finder<'query, T, E, C>
 where
     T: Send + Unpin + for<'r> FromRow<'r, sqlx::sqlite::SqliteRow>,
@@ -59,7 +70,17 @@ where
             _executor: PhantomData,
         }
     }
-
+    pub fn offset(self, offset: usize) -> Self {
+        Self {
+            query: self.query.offset(offset),
+            _entity: PhantomData,
+            _executor: PhantomData,
+        }
+    }
+    /// Returns a paginator for this finder with the given page size.
+    pub fn paginate(self, page_size: usize) -> Paginator<'query, T, E, C> {
+        Paginator::new(self, page_size)
+    }
     /// Fetches a single row from the query.
     pub async fn one(self, executor: &mut E) -> Result<T, CorrosionOrmError> {
         let mut ctx = QueryContext::new();

--- a/crates/corrosion-orm-core/src/model/finder.rs
+++ b/crates/corrosion-orm-core/src/model/finder.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 
 use crate::{
     CorrosionOrmError, Executor,
-    model::paginator::Paginator,
+    model::{cursor_paginator::CursorPaginator, paginator::Paginator},
     prelude::QueryContext,
     query::{Select, ToSql, WhereClause, order_by::OrderBy},
     types::ColumnTrait,
@@ -62,7 +62,6 @@ where
         }
     }
     /// Adds an order to order clause in the query.
-    ///
     pub fn add_order_by(self, order_by: OrderBy<C>) -> Self {
         Self {
             query: self.query.add_order_by(order_by),
@@ -70,6 +69,7 @@ where
             _executor: PhantomData,
         }
     }
+    /// Sets the offset for the query.
     pub fn offset(self, offset: usize) -> Self {
         Self {
             query: self.query.offset(offset),
@@ -80,6 +80,13 @@ where
     /// Returns a paginator for this finder with the given page size.
     pub fn paginate(self, page_size: usize) -> Paginator<'query, T, E, C> {
         Paginator::new(self, page_size)
+    }
+    /// Returns a cursor paginator for this finder with the given page size.
+    pub fn cursor_paginate(self, page_size: usize) -> CursorPaginator<'query, T, E, C>
+    where
+        T: Clone,
+    {
+        CursorPaginator::new(self, page_size)
     }
     /// Fetches a single row from the query.
     pub async fn one(self, executor: &mut E) -> Result<T, CorrosionOrmError> {

--- a/crates/corrosion-orm-core/src/model/mod.rs
+++ b/crates/corrosion-orm-core/src/model/mod.rs
@@ -1,6 +1,9 @@
 //! Repository trait for database operations on entities.
+pub mod cursor_paginator;
 pub mod finder;
-mod paginator;
+pub mod paginator;
 pub mod repository;
 
+pub use cursor_paginator::CursorPaginator;
 pub use finder::Finder;
+pub use paginator::Paginator;

--- a/crates/corrosion-orm-core/src/model/mod.rs
+++ b/crates/corrosion-orm-core/src/model/mod.rs
@@ -1,4 +1,6 @@
 //! Repository trait for database operations on entities.
 pub mod finder;
+mod paginator;
 pub mod repository;
+
 pub use finder::Finder;

--- a/crates/corrosion-orm-core/src/model/paginator.rs
+++ b/crates/corrosion-orm-core/src/model/paginator.rs
@@ -1,0 +1,51 @@
+use crate::{CorrosionOrmError, Executor, model::Finder, types::ColumnTrait};
+
+pub struct Paginator<'query, T, E: Executor, C: ColumnTrait> {
+    finder: Finder<'query, T, E, C>,
+    page_size: usize,
+    current_page: usize,
+}
+
+impl<'query, T, E: Executor, C: ColumnTrait> Paginator<'query, T, E, C>
+where
+    T: Send + Unpin + for<'r> sqlx::FromRow<'r, sqlx::sqlite::SqliteRow>,
+{
+    pub fn new(finder: Finder<'query, T, E, C>, page_size: usize) -> Self {
+        Self {
+            finder,
+            page_size,
+            current_page: 0,
+        }
+    }
+    /// Fetch the page of results from the database.
+    ///
+    /// page parameter is index of page to fetch.
+    pub async fn fetch_page(
+        &mut self,
+        db: &mut E,
+        page: usize,
+    ) -> Result<Vec<T>, CorrosionOrmError> {
+        self.current_page = page;
+        let offset = self.current_page * self.page_size;
+        let res = self
+            .finder
+            .clone()
+            .offset(offset)
+            .limit(self.page_size)
+            .all(db)
+            .await?;
+        Ok(res)
+    }
+    /// Fetches the next page of results from the database.
+    ///
+    /// Returns `None` if there are no more pages.
+    pub async fn fetch_next(&mut self, db: &mut E) -> Result<Option<Vec<T>>, CorrosionOrmError> {
+        let res = self.fetch_page(db, self.current_page).await?;
+        if res.is_empty() {
+            Ok(None)
+        } else {
+            self.current_page += 1;
+            Ok(Some(res))
+        }
+    }
+}

--- a/crates/corrosion-orm-core/src/model/paginator.rs
+++ b/crates/corrosion-orm-core/src/model/paginator.rs
@@ -1,3 +1,86 @@
+//! Offset-based pagination for database queries.
+//!
+//! This module provides the [`Paginator`] struct, which implements traditional
+//! offset-based pagination using page numbers and SQL `OFFSET` clauses. This is the
+//! classic pagination strategy familiar to most web developers.
+//!
+//! # Understanding Offset-Based Pagination
+//!
+//! Offset-based pagination works by:
+//! 1. Taking a `page` number (0-indexed)
+//! 2. Calculating offset = `page × page_size`
+//! 3. Using `OFFSET offset LIMIT page_size` in the SQL query
+//! 4. Returning the results for that page
+//!
+//! # When to Use Offset-Based Pagination
+//!
+//! Offset-based pagination with [`Paginator`] is best suited for:
+//! - **Small to medium datasets** (< 100,000 rows)
+//! - **Admin panels and dashboards** with manageable record counts
+//! - **Traditional user interfaces** showing page numbers (1, 2, 3, ...)
+//! - **Allowing arbitrary page access** (jump to page 5 directly)
+//! - **Relatively static data** that doesn't change frequently
+//! - **Simple implementations** where ease-of-use is valued
+//!
+//! # When NOT to Use Offset-Based Pagination
+//!
+//! Offset-based pagination is **not ideal** for:
+//! - **Large datasets** (millions of rows) - Later pages become very slow
+//! - **High-performance APIs** - OFFSET performance degrades with page depth
+//! - **Real-time data** with frequent inserts/deletes - Can cause duplicate/missing rows
+//! - **Infinite scroll patterns** - Better served by cursor pagination
+//! - **Deep pagination** (page 1000+) - Extremely slow as database skips many rows
+//!
+//! In these cases, consider using [`crate::model::CursorPaginator`] instead.
+//!
+//! # Performance Characteristics
+//!
+//! - **Early pages** (0-10): Fast, ~O(n) where n = page_size
+//! - **Middle pages** (100-1000): Noticeably slower, ~O(offset + page_size)
+//! - **Late pages** (10000+): Very slow, database must scan/skip many rows
+//!
+//! This is because the database must process every row up to the offset point,
+//! even though most are discarded.
+//!
+//! # Example: Basic Usage
+//!
+//! ```ignore
+//! use corrosion_orm_core::model::Paginator;
+//!
+//! let mut paginator = Paginator::new(
+//!     User::find().order_by(user::COLUMN.CreatedAt.desc()),
+//!     20 // 20 items per page
+//! );
+//!
+//! // Jump to page 5
+//! let page_5 = paginator.fetch_page(&mut db, 5).await?;
+//! for user in page_5 {
+//!     println!("{}: {}", user.id, user.email);
+//! }
+//! ```
+//!
+//! # Example: Sequential Navigation
+//!
+//! ```ignore
+//! use corrosion_orm_core::model::Paginator;
+//!
+//! let mut paginator = Paginator::new(
+//!     Post::find().order_by(post::COLUMN.CreatedAt.desc()),
+//!     50
+//! );
+//!
+//! // Iterate through pages sequentially
+//! while let Some(posts) = paginator.fetch_next(&mut db).await? {
+//!     for post in posts {
+//!         println!("Post: {}", post.title);
+//!     }
+//! }
+//! ```
+//!
+//! # See Also
+//!
+//! - [`crate::model::CursorPaginator`] - Cursor-based pagination for large datasets,
+//!   real-time data, and consistent O(1) performance
 use crate::{CorrosionOrmError, Executor, model::Finder, types::ColumnTrait};
 
 pub struct Paginator<'query, T, E: Executor, C: ColumnTrait> {

--- a/crates/corrosion-orm-core/src/query/select.rs
+++ b/crates/corrosion-orm-core/src/query/select.rs
@@ -45,8 +45,9 @@ pub struct Select<'query, C: ColumnTrait> {
     table: Cow<'query, str>,
     columns: Vec<Cow<'query, str>>,
     where_clause: Option<WhereClause<C>>,
-    limit: Option<usize>,
     order_by: Option<OrderClause<C>>,
+    limit: Option<usize>,
+    offset: Option<usize>,
 }
 
 impl<'col, C: ColumnTrait> Select<'col, C> {
@@ -57,6 +58,7 @@ impl<'col, C: ColumnTrait> Select<'col, C> {
             where_clause: None,
             order_by: None,
             limit: None,
+            offset: None,
         }
     }
     pub fn add_column<Column: Into<Cow<'col, str>>>(mut self, column: Column) -> Self {
@@ -69,6 +71,10 @@ impl<'col, C: ColumnTrait> Select<'col, C> {
     }
     pub fn limit(mut self, limit: usize) -> Self {
         self.limit = Some(limit);
+        self
+    }
+    pub fn offset(mut self, offset: usize) -> Self {
+        self.offset = Some(offset);
         self
     }
     pub fn where_clause(mut self, where_clause: WhereClause<C>) -> Self {
@@ -125,6 +131,9 @@ impl<C: ColumnTrait> ToSql for Select<'_, C> {
         if let Some(limit) = self.limit {
             ctx.sql.push_str(&format!(" LIMIT {}", limit));
         }
+        if let Some(offset) = self.offset {
+            ctx.sql.push_str(&format!(" OFFSET {}", offset));
+        }
     }
 }
 impl<'col, C: ColumnTrait> From<&'col TableSchemaModel> for Select<'col, C> {
@@ -139,6 +148,7 @@ impl<'col, C: ColumnTrait> From<&'col TableSchemaModel> for Select<'col, C> {
             where_clause: None,
             order_by: None,
             limit: None,
+            offset: None,
         }
     }
 }
@@ -158,6 +168,7 @@ impl<'col, C: ColumnTrait> From<TableSchemaModel> for Select<'col, C> {
             where_clause: None,
             order_by: None,
             limit: None,
+            offset: None,
         }
     }
 }

--- a/crates/corrosion-orm-core/src/query/where_clause.rs
+++ b/crates/corrosion-orm-core/src/query/where_clause.rs
@@ -61,6 +61,21 @@ impl<C: ColumnTrait> WhereClause<C> {
     pub fn not_(self) -> Self {
         Self::new(WhereClauseType::Not(Box::new(self.clause)))
     }
+
+    pub fn seek_after(
+        sort_col: C,
+        last_val: impl Into<Value>,
+        unique_col: C,
+        last_unique_val: impl Into<Value>,
+    ) -> Self {
+        let last_val = last_val.into();
+        let last_unique_val = last_unique_val.into();
+
+        let greater = Self::gt(sort_col, last_val.clone());
+        let tie_breaker = Self::eq(sort_col, last_val).and(Self::gt(unique_col, last_unique_val));
+
+        greater.or(tie_breaker)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/corrosion-orm-test/src/repository_test/find_test.rs
+++ b/crates/corrosion-orm-test/src/repository_test/find_test.rs
@@ -145,6 +145,69 @@ mod tests {
                 }
             }
         }
+        Ok(())
+    }
+    #[tokio::test]
+    async fn test_find_cursor_pagination() -> Result<(), CorrosionOrmError> {
+        let db = init_sqlite().await;
+        let mut conn = db.acquire_conn().await.unwrap();
+        init_users(&mut conn, USER_COUNT).await?;
+
+        let mut cursor = User::find()
+            .add_order_by(user::COLUMN.id.asc())
+            .cursor_paginate(2);
+
+        let page1 = cursor
+            .fetch_next(
+                &mut conn,
+                |u| Value::Int(u.id),
+                |u| Value::Int(u.id),
+                user::Column::id,
+                user::Column::id,
+            )
+            .await?
+            .unwrap();
+        assert_eq!(page1.len(), 2);
+        assert_eq!(page1[0].id, 1);
+        assert_eq!(page1[1].id, 2);
+
+        let page2 = cursor
+            .fetch_next(
+                &mut conn,
+                |u| Value::Int(u.id),
+                |u| Value::Int(u.id),
+                user::Column::id,
+                user::Column::id,
+            )
+            .await?
+            .unwrap();
+        assert_eq!(page2.len(), 2);
+        assert_eq!(page2[0].id, 3);
+        assert_eq!(page2[1].id, 4);
+
+        let page3 = cursor
+            .fetch_next(
+                &mut conn,
+                |u| Value::Int(u.id),
+                |u| Value::Int(u.id),
+                user::Column::id,
+                user::Column::id,
+            )
+            .await?
+            .unwrap();
+        assert_eq!(page3.len(), 1);
+        assert_eq!(page3[0].id, 5);
+
+        let empty = cursor
+            .fetch_next(
+                &mut conn,
+                |u| Value::Int(u.id),
+                |u| Value::Int(u.id),
+                user::Column::id,
+                user::Column::id,
+            )
+            .await?;
+        assert!(empty.is_none());
 
         Ok(())
     }

--- a/crates/corrosion-orm-test/src/repository_test/find_test.rs
+++ b/crates/corrosion-orm-test/src/repository_test/find_test.rs
@@ -114,4 +114,38 @@ mod tests {
         assert_eq!(users.first().unwrap().id, USER_COUNT as i32);
         Ok(())
     }
+    #[tokio::test]
+    async fn test_find_pagination() -> Result<(), CorrosionOrmError> {
+        let db = init_sqlite().await;
+        let mut conn = db.acquire_conn().await.unwrap();
+        init_users(&mut conn, USER_COUNT).await?;
+        let mut paginator = User::find().add_order_by(user::COLUMN.id.asc()).paginate(2);
+        let page1 = paginator.fetch_page(&mut conn, 0).await?;
+        assert_eq!(page1[0].id, 1);
+        assert_eq!(page1[1].id, 2);
+        let page2 = paginator.fetch_page(&mut conn, 1).await?;
+        assert_eq!(page2[0].id, 3);
+        assert_eq!(page2[1].id, 4);
+        let page3 = paginator.fetch_page(&mut conn, 2).await?;
+        assert_eq!(page3.len(), 1);
+        assert_eq!(page3[0].id, 5);
+        Ok(())
+    }
+    #[tokio::test]
+    async fn test_find_pagination_next() -> Result<(), CorrosionOrmError> {
+        let db = init_sqlite().await;
+        let mut conn = db.acquire_conn().await.unwrap();
+        init_users(&mut conn, USER_COUNT).await?;
+        let mut paginator = User::find().add_order_by(user::COLUMN.id.asc()).paginate(2);
+        for i in 0..3 {
+            if let Some(page) = paginator.fetch_next(&mut conn).await? {
+                assert_eq!(page[0].id, (i * 2 + 1) as i32);
+                if page.len() > 1 {
+                    assert_eq!(page[1].id, (i * 2 + 2) as i32);
+                }
+            }
+        }
+
+        Ok(())
+    }
 }

--- a/crates/corrosion-orm-test/src/repository_test/find_test.rs
+++ b/crates/corrosion-orm-test/src/repository_test/find_test.rs
@@ -139,9 +139,9 @@ mod tests {
         let mut paginator = User::find().add_order_by(user::COLUMN.id.asc()).paginate(2);
         for i in 0..3 {
             if let Some(page) = paginator.fetch_next(&mut conn).await? {
-                assert_eq!(page[0].id, (i * 2 + 1) as i32);
+                assert_eq!(page[0].id, (i * 2 + 1));
                 if page.len() > 1 {
-                    assert_eq!(page[1].id, (i * 2 + 2) as i32);
+                    assert_eq!(page[1].id, (i * 2 + 2));
                 }
             }
         }


### PR DESCRIPTION
This pull request introduces robust, flexible pagination support to the ORM core, adding both offset-based and cursor-based pagination strategies. It includes new `Paginator` and `CursorPaginator` types, integrates them into the `Finder` API, and updates the query builder to support SQL `OFFSET`. Comprehensive documentation and tests are provided to ensure correct usage and behavior.

**Pagination features:**

* Added a new `Paginator` struct for offset-based pagination (classic page number style), and a `CursorPaginator` struct for cursor-based (keyset) pagination, each with detailed module-level documentation describing their use cases, trade-offs, and performance characteristics. (`crates/corrosion-orm-core/src/model/paginator.rs` [[1]](diffhunk://#diff-78e63b36e4723c122403874fdaf0e4c3380231a74e01e5fdbb138d5ded2fece7R1-R134) `crates/corrosion-orm-core/src/model/cursor_paginator.rs` [[2]](diffhunk://#diff-604ec13b1a73f1dc02c35c69fe0f59e61ab14db93b9b61411df1d96ccf71989bR1-R119)
* Exposed `Paginator` and `CursorPaginator` in the `prelude` and `model` modules for easy access. (`crates/corrosion-orm-core/src/model/mod.rs` [[1]](diffhunk://#diff-300709b08a1ef5034ec828b1a7d0c1361178c50d186403d6e12efa7c365e5a34R2-R9) `crates/corrosion-orm-core/src/lib.rs` [[2]](diffhunk://#diff-b5e53d6f49da84a364cb91187cacb7db72c188cff77d31d9d1896f6746648ed6R30)

**Finder API enhancements:**

* The `Finder` struct now provides `.paginate(page_size)` and `.cursor_paginate(page_size)` methods, returning the respective paginator types. It also supports `.offset(offset)` for manual offset control. (`crates/corrosion-orm-core/src/model/finder.rs` [crates/corrosion-orm-core/src/model/finder.rsL54-R90](diffhunk://#diff-ef61c969e661078199791c9a2b28dd3bf535428a64e8dbc77d6188a62ea1a153L54-R90))
* Implemented `Clone` for `Finder` to facilitate use in paginators. (`crates/corrosion-orm-core/src/model/finder.rs` [crates/corrosion-orm-core/src/model/finder.rsL20-R31](diffhunk://#diff-ef61c969e661078199791c9a2b28dd3bf535428a64e8dbc77d6188a62ea1a153L20-R31))

**Query builder improvements:**

* The `Select` query builder now supports an `offset` field and method, and generates correct SQL including `OFFSET` clauses. (`crates/corrosion-orm-core/src/query/select.rs` [[1]](diffhunk://#diff-7bcd566a02501b4b8356370919977f43212dd1b0fd9d5bed310fca792dd935e1L48-R50) [[2]](diffhunk://#diff-7bcd566a02501b4b8356370919977f43212dd1b0fd9d5bed310fca792dd935e1R76-R79) [[3]](diffhunk://#diff-7bcd566a02501b4b8356370919977f43212dd1b0fd9d5bed310fca792dd935e1R134-R136)
* Added a `seek_after` method to `WhereClause` to support efficient keyset pagination logic for cursor-based pagination. (`crates/corrosion-orm-core/src/query/where_clause.rs` [crates/corrosion-orm-core/src/query/where_clause.rsR64-R78](diffhunk://#diff-328f1224e2b3728ce9660ca3fa721336776c59a328e98c28ffa10c0f05ed8f79R64-R78))

**Testing:**

* Added comprehensive tests for both offset-based and cursor-based pagination to ensure correct ordering, page boundaries, and end-of-results handling. (`crates/corrosion-orm-test/src/repository_test/find_test.rs` [crates/corrosion-orm-test/src/repository_test/find_test.rsR117-R213](diffhunk://#diff-3ad0fe9859f853d0bd70fa3f35ea42bcc8211036c3535238fda3761c822e1284R117-R213))

These changes provide a solid foundation for scalable, high-performance pagination in applications using the ORM, with clear guidance for when to use each approach.