### PR TITLE
feat: Date data types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -125,6 +134,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,14 +169,15 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.9"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
- "libc",
- "num-integer",
+ "iana-time-zone",
+ "js-sys",
  "num-traits",
- "time",
+ "wasm-bindgen",
+ "windows-link",
 ]
 
 [[package]]
@@ -198,6 +214,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "corrosion-orm-core"
 version = "0.1.0"
 dependencies = [
@@ -227,6 +249,7 @@ dependencies = [
 name = "corrosion-orm-test"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "corrosion-orm-core",
  "corrosion-orm-macros",
  "env_logger",
@@ -569,7 +592,7 @@ checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -654,6 +677,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -831,6 +878,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,7 +987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.61.2",
 ]
 
@@ -1263,6 +1320,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1454,6 +1517,7 @@ checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
  "base64",
  "bytes",
+ "chrono",
  "crc",
  "crossbeam-queue",
  "either",
@@ -1529,6 +1593,7 @@ dependencies = [
  "bitflags",
  "byteorder",
  "bytes",
+ "chrono",
  "crc",
  "digest",
  "dotenvy",
@@ -1570,6 +1635,7 @@ dependencies = [
  "base64",
  "bitflags",
  "byteorder",
+ "chrono",
  "crc",
  "dotenvy",
  "etcetera",
@@ -1604,6 +1670,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
 dependencies = [
  "atoi",
+ "chrono",
  "flume",
  "futures-channel",
  "futures-core",
@@ -1703,17 +1770,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
 ]
 
 [[package]]
@@ -1917,12 +1973,6 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
@@ -1950,6 +2000,51 @@ name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-encoder"
@@ -1996,32 +2091,63 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
+name = "windows-core"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
+name = "windows-implement"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
+name = "windows-interface"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ quote = "1.0"
 proc-macro2 = "1.0"
 deluxe = "0.5.0"
 anyhow = "1.0.100"
-chrono = "0.4.9"
+chrono = "0.4.44"
 thiserror = "2.0.18"
 insta = "1.46.3"
 tokio = { version = "1.50.0", features = ["full"] }

--- a/crates/corrosion-orm-core/Cargo.toml
+++ b/crates/corrosion-orm-core/Cargo.toml
@@ -11,7 +11,7 @@ test-utils = []
 chrono  = { workspace = true }
 deluxe  = { workspace = true }
 thiserror = { workspace = true }
-sqlx = { version = "0.8.6", optional = true, default-features = false }
+sqlx = { version = "0.8.6", optional = true, default-features = false, features = [ "runtime-tokio", "chrono"] }
 log = { workspace = true, optional = true }
 tokio = { workspace = true }
 trait-variant = "0.1.2"

--- a/crates/corrosion-orm-core/src/driver/sqlite_driver/sqlite_connection.rs
+++ b/crates/corrosion-orm-core/src/driver/sqlite_driver/sqlite_connection.rs
@@ -8,6 +8,18 @@ use crate::{
     error::CorrosionOrmError,
     query::query_type::{QueryContext, Value},
 };
+macro_rules! bind_to_query {
+    ($query: expr, $value: expr) => {
+        match $value {
+            Value::String(s) => $query.bind(s),
+            Value::Int(i) => $query.bind(i),
+            Value::Int64(i) => $query.bind(i),
+            Value::Bool(b) => $query.bind(b),
+            Value::Date(d) => $query.bind(d),
+            Value::DateTime(d) => $query.bind(d),
+        }
+    };
+}
 pub struct CorrosionSqliteConnection {
     pub(crate) inner: sqlx::pool::PoolConnection<sqlx::Sqlite>,
 }
@@ -22,14 +34,7 @@ impl crate::driver::connection::Conn for CorrosionSqliteConnection {
         let mut query = sqlx::query(&ctx.sql);
 
         for value in ctx.values.iter() {
-            query = match value {
-                Value::String(s) => query.bind(s),
-                Value::Int(i) => query.bind(i),
-                Value::Int64(i) => query.bind(i),
-                Value::Bool(b) => query.bind(b),
-                Value::Date(d) => query.bind(d.to_string()),
-                Value::DateTime(d) => query.bind(d.to_string()),
-            }
+            query = bind_to_query!(query, value)
         }
 
         let result = query
@@ -79,14 +84,7 @@ impl crate::driver::connection::Conn for CorrosionSqliteConnection {
         let mut query = sqlx::query_as::<_, T>(&ctx.sql);
 
         for value in ctx.values.iter() {
-            query = match value {
-                Value::String(s) => query.bind(s),
-                Value::Int(i) => query.bind(i),
-                Value::Int64(i) => query.bind(i),
-                Value::Bool(b) => query.bind(b),
-                Value::Date(d) => query.bind(d.to_string()),
-                Value::DateTime(d) => query.bind(d.to_string()),
-            }
+            query = bind_to_query!(query, value)
         }
 
         let result = query
@@ -103,14 +101,7 @@ impl crate::driver::connection::Conn for CorrosionSqliteConnection {
         let mut query = sqlx::query_as::<_, E>(&ctx.sql);
 
         for value in ctx.values.iter() {
-            query = match value {
-                Value::String(s) => query.bind(s),
-                Value::Int(i) => query.bind(i),
-                Value::Int64(i) => query.bind(i),
-                Value::Bool(b) => query.bind(b),
-                Value::Date(d) => query.bind(d.to_string()),
-                Value::DateTime(d) => query.bind(d.to_string()),
-            }
+            query = bind_to_query!(query, value)
         }
 
         let result = query
@@ -127,14 +118,7 @@ impl crate::driver::connection::Conn for CorrosionSqliteConnection {
         let mut query = sqlx::query_as::<_, E>(&ctx.sql);
 
         for value in ctx.values.iter() {
-            query = match value {
-                Value::String(s) => query.bind(s),
-                Value::Int(i) => query.bind(i),
-                Value::Int64(i) => query.bind(i),
-                Value::Bool(b) => query.bind(b),
-                Value::Date(d) => query.bind(d.to_string()),
-                Value::DateTime(d) => query.bind(d.to_string()),
-            }
+            query = bind_to_query!(query, value)
         }
 
         let result = query

--- a/crates/corrosion-orm-core/src/driver/sqlite_driver/sqlite_connection.rs
+++ b/crates/corrosion-orm-core/src/driver/sqlite_driver/sqlite_connection.rs
@@ -27,6 +27,8 @@ impl crate::driver::connection::Conn for CorrosionSqliteConnection {
                 Value::Int(i) => query.bind(i),
                 Value::Int64(i) => query.bind(i),
                 Value::Bool(b) => query.bind(b),
+                Value::Date(d) => query.bind(d.to_string()),
+                Value::DateTime(d) => query.bind(d.to_string()),
             }
         }
 
@@ -82,6 +84,8 @@ impl crate::driver::connection::Conn for CorrosionSqliteConnection {
                 Value::Int(i) => query.bind(i),
                 Value::Int64(i) => query.bind(i),
                 Value::Bool(b) => query.bind(b),
+                Value::Date(d) => query.bind(d.to_string()),
+                Value::DateTime(d) => query.bind(d.to_string()),
             }
         }
 
@@ -104,6 +108,8 @@ impl crate::driver::connection::Conn for CorrosionSqliteConnection {
                 Value::Int(i) => query.bind(i),
                 Value::Int64(i) => query.bind(i),
                 Value::Bool(b) => query.bind(b),
+                Value::Date(d) => query.bind(d.to_string()),
+                Value::DateTime(d) => query.bind(d.to_string()),
             }
         }
 
@@ -126,6 +132,8 @@ impl crate::driver::connection::Conn for CorrosionSqliteConnection {
                 Value::Int(i) => query.bind(i),
                 Value::Int64(i) => query.bind(i),
                 Value::Bool(b) => query.bind(b),
+                Value::Date(d) => query.bind(d.to_string()),
+                Value::DateTime(d) => query.bind(d.to_string()),
             }
         }
 

--- a/crates/corrosion-orm-core/src/query/query_type.rs
+++ b/crates/corrosion-orm-core/src/query/query_type.rs
@@ -8,6 +8,8 @@ pub enum Value {
     Int(i32),
     Int64(i64),
     Bool(bool),
+    Date(chrono::NaiveDate),
+    DateTime(chrono::NaiveDateTime),
 }
 
 macro_rules! impl_from_value {
@@ -40,7 +42,16 @@ impl From<&str> for Value {
         Value::String(v.to_string())
     }
 }
-
+impl From<chrono::NaiveDate> for Value {
+    fn from(v: chrono::NaiveDate) -> Self {
+        Value::Date(v)
+    }
+}
+impl From<chrono::NaiveDateTime> for Value {
+    fn from(v: chrono::NaiveDateTime) -> Self {
+        Value::DateTime(v)
+    }
+}
 impl<T> From<Option<T>> for Value
 where
     Value: From<T>,
@@ -81,6 +92,8 @@ impl QueryContext {
                     Value::Int(i) => i.to_string(),
                     Value::Int64(i) => i.to_string(),
                     Value::Bool(b) => if *b { "1" } else { "0" }.to_string(),
+                    Value::Date(d) => format!("'{}'", d),
+                    Value::DateTime(naive_date_time) => format!("'{}'", naive_date_time),
                 };
                 sql.replace_range(pos..pos + placeholder.len(), &value_str);
             }

--- a/crates/corrosion-orm-core/src/types/column.rs
+++ b/crates/corrosion-orm-core/src/types/column.rs
@@ -181,24 +181,4 @@ impl<C: ColumnTrait> BooleanColumn<C> {
     pub const fn new(column: C) -> Self {
         Self { column }
     }
-    pub fn gt<V: Into<Value>>(self, val: V) -> WhereClause<C> {
-        WhereClause::gt(self.column, val)
-    }
-    pub fn gte<V: Into<Value>>(self, val: V) -> WhereClause<C> {
-        WhereClause::new(WhereClauseType::Condition(Condition::gte(self.column, val)))
-    }
-    pub fn lt<V: Into<Value>>(self, val: V) -> WhereClause<C> {
-        WhereClause::lt(self.column, val)
-    }
-    pub fn lte<V: Into<Value>>(self, val: V) -> WhereClause<C> {
-        WhereClause::new(WhereClauseType::Condition(Condition::lte(self.column, val)))
-    }
-
-    pub fn between<V: Into<Value>>(self, min: V, max: V) -> WhereClause<C> {
-        WhereClause::new(WhereClauseType::Condition(Condition::between(
-            self.column,
-            min,
-            max,
-        )))
-    }
 }

--- a/crates/corrosion-orm-core/src/types/column.rs
+++ b/crates/corrosion-orm-core/src/types/column.rs
@@ -181,4 +181,24 @@ impl<C: ColumnTrait> BooleanColumn<C> {
     pub const fn new(column: C) -> Self {
         Self { column }
     }
+    pub fn gt<V: Into<Value>>(self, val: V) -> WhereClause<C> {
+        WhereClause::gt(self.column, val)
+    }
+    pub fn gte<V: Into<Value>>(self, val: V) -> WhereClause<C> {
+        WhereClause::new(WhereClauseType::Condition(Condition::gte(self.column, val)))
+    }
+    pub fn lt<V: Into<Value>>(self, val: V) -> WhereClause<C> {
+        WhereClause::lt(self.column, val)
+    }
+    pub fn lte<V: Into<Value>>(self, val: V) -> WhereClause<C> {
+        WhereClause::new(WhereClauseType::Condition(Condition::lte(self.column, val)))
+    }
+
+    pub fn between<V: Into<Value>>(self, min: V, max: V) -> WhereClause<C> {
+        WhereClause::new(WhereClauseType::Condition(Condition::between(
+            self.column,
+            min,
+            max,
+        )))
+    }
 }

--- a/crates/corrosion-orm-macros/src/generator/entity_gen.rs
+++ b/crates/corrosion-orm-macros/src/generator/entity_gen.rs
@@ -55,6 +55,8 @@ fn get_sql_type_from_rust_type(ty: &Type) -> SqlType {
                 let ident_str = segment.ident.to_string();
                 match ident_str.as_str() {
                     "String" => String::default().to_sql_type(),
+                    "NaiveDate" => SqlType::Date,
+                    "NaiveDateTime" => SqlType::Timestamp,
                     "bool" => bool::default().to_sql_type(),
                     "i32" => i32::default().to_sql_type(),
                     "i64" => i64::default().to_sql_type(),

--- a/crates/corrosion-orm-test/Cargo.toml
+++ b/crates/corrosion-orm-test/Cargo.toml
@@ -8,5 +8,6 @@ corrosion-orm-macros = {path="../corrosion-orm-macros"}
 insta = { workspace = true }
 tokio = { workspace = true }
 sqlx = {version = "0.8.6", features = ["runtime-tokio","sqlite"]}
+chrono = { workspace = true }
 env_logger = "0.11"
 log = { workspace = true }

--- a/crates/corrosion-orm-test/src/repository_test/find_test.rs
+++ b/crates/corrosion-orm-test/src/repository_test/find_test.rs
@@ -2,6 +2,7 @@
 mod tests {
     use crate::{User, init_sqlite, user};
     use corrosion_orm_core::prelude::*;
+    use corrosion_orm_macros::Model;
     const USER_COUNT: usize = 5;
     async fn init_users(conn: &mut impl Executor, n: usize) -> Result<(), CorrosionOrmError> {
         for i in 1..n + 1 {
@@ -209,6 +210,63 @@ mod tests {
             .await?;
         assert!(empty.is_none());
 
+        Ok(())
+    }
+    #[derive(Model)]
+    struct Post {
+        #[PrimaryKey]
+        id: i32,
+        date: chrono::NaiveDate,
+        date_time: chrono::NaiveDateTime,
+    }
+    const D: chrono::NaiveDate = chrono::NaiveDate::from_ymd_opt(2023, 1, 1).unwrap();
+    const T: chrono::NaiveTime = chrono::NaiveTime::from_hms_milli_opt(12, 34, 56, 789).unwrap();
+
+    #[tokio::test]
+    async fn test_find_date() -> Result<(), CorrosionOrmError> {
+        let db = init_sqlite().await;
+        let mut conn = db.acquire_conn().await.unwrap();
+        let mut ctx = QueryContext::from_model(Post::get_schema(), conn.get_dialect());
+
+        conn.execute_query(&mut ctx).await?;
+
+        let post = Post {
+            id: 1,
+            date: D,
+            date_time: chrono::NaiveDateTime::new(D, T),
+        };
+        post.save(&mut conn).await?;
+        let posts = Post::find()
+            .filter(post::COLUMN.date.eq(D))
+            .all(&mut conn)
+            .await?;
+        assert_eq!(posts.len(), 1);
+        assert_eq!(posts[0].id, 1);
+        assert_eq!(posts[0].date, D);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_find_datetime() -> Result<(), CorrosionOrmError> {
+        let db = init_sqlite().await;
+        let mut conn = db.acquire_conn().await.unwrap();
+        let mut ctx = QueryContext::from_model(Post::get_schema(), conn.get_dialect());
+
+        conn.execute_query(&mut ctx).await?;
+        let date_time = chrono::NaiveDateTime::new(D, T);
+        let post = Post {
+            id: 1,
+            date: D,
+            date_time: chrono::NaiveDateTime::new(D, T),
+        };
+        post.save(&mut conn).await?;
+        let posts = Post::find()
+            .filter(post::COLUMN.date_time.eq(date_time))
+            .all(&mut conn)
+            .await?;
+        assert_eq!(posts.len(), 1);
+        assert_eq!(posts[0].id, 1);
+        assert_eq!(posts[0].date_time, date_time);
         Ok(())
     }
 }


### PR DESCRIPTION
This pull request adds support for `chrono::NaiveDate` and `chrono::NaiveDateTime` types throughout the ORM, enabling date and datetime handling in queries, models, and tests. It introduces these types to the query value system, updates the SQLite driver to bind them, and provides comprehensive tests to ensure correct functionality. Additionally, it updates dependencies and improves feature flags for better integration with `sqlx` and `chrono`.

**Date and DateTime support:**

* Added `Value::Date` and `Value::DateTime` variants to the `Value` enum, along with `From` implementations for `chrono::NaiveDate` and `chrono::NaiveDateTime`, and updated SQL string conversion logic to handle these types (`crates/corrosion-orm-core/src/query/query_type.rs`). [[1]](diffhunk://#diff-3071a76d669122990dadcfb8d7a5a594c0b4f2cf5e2d2e0581d40f53a373bad1R11-R12) [[2]](diffhunk://#diff-3071a76d669122990dadcfb8d7a5a594c0b4f2cf5e2d2e0581d40f53a373bad1L43-R54) [[3]](diffhunk://#diff-3071a76d669122990dadcfb8d7a5a594c0b4f2cf5e2d2e0581d40f53a373bad1R95-R96)
* Updated the SQLite connection logic to bind `Date` and `DateTime` values in queries by introducing a `bind_to_query!` macro and using it in all relevant query methods (`crates/corrosion-orm-core/src/driver/sqlite_driver/sqlite_connection.rs`). [[1]](diffhunk://#diff-c86195db3f0b0a3d0ce6678751536203b78849cf213ba59dc2c96d222ce1c6bdR11-R22) [[2]](diffhunk://#diff-c86195db3f0b0a3d0ce6678751536203b78849cf213ba59dc2c96d222ce1c6bdL25-R37) [[3]](diffhunk://#diff-c86195db3f0b0a3d0ce6678751536203b78849cf213ba59dc2c96d222ce1c6bdL80-R87) [[4]](diffhunk://#diff-c86195db3f0b0a3d0ce6678751536203b78849cf213ba59dc2c96d222ce1c6bdL102-R104) [[5]](diffhunk://#diff-c86195db3f0b0a3d0ce6678751536203b78849cf213ba59dc2c96d222ce1c6bdL124-R121)
* Enhanced the entity macro code generation to map Rust `NaiveDate` and `NaiveDateTime` types to SQL `Date` and `Timestamp` types (`crates/corrosion-orm-macros/src/generator/entity_gen.rs`).

**Testing and validation:**

* Added new tests for date and datetime query functionality using a `Post` model, ensuring correct save and filter operations with these types (`crates/corrosion-orm-test/src/repository_test/find_test.rs`).

**Dependency and feature updates:**

* Updated `chrono` to version `0.4.44` and ensured it is included in all relevant crates; updated `sqlx` features to enable `runtime-tokio` and `chrono` support (`Cargo.toml`, `crates/corrosion-orm-core/Cargo.toml`, `crates/corrosion-orm-test/Cargo.toml`). [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L15-R15) [[2]](diffhunk://#diff-c359d78cf1a1154218caaaa3901436725660a25c08966be1f0c0d369a8943db5L14-R14) [[3]](diffhunk://#diff-dc982f0fdfb7fa23e0b317d60da877b2fa25bde16b5ff7c5cd3756e18b26618aR11)

**Miscellaneous:**

* Minor import and derive macro additions to support new tests and model definitions (`crates/corrosion-orm-test/src/repository_test/find_test.rs`).