### PR TITLE
feat: Add lazy relation types and nullable Value support

### DIFF
--- a/crates/corrosion-orm-core/src/driver/sqlite_driver/sqlite_connection.rs
+++ b/crates/corrosion-orm-core/src/driver/sqlite_driver/sqlite_connection.rs
@@ -17,6 +17,7 @@ macro_rules! bind_to_query {
             Value::Bool(b) => $query.bind(b),
             Value::Date(d) => $query.bind(d),
             Value::DateTime(d) => $query.bind(d),
+            Value::Null => $query.bind(Option::<String>::None),
         }
     };
 }

--- a/crates/corrosion-orm-core/src/lib.rs
+++ b/crates/corrosion-orm-core/src/lib.rs
@@ -30,6 +30,7 @@ pub mod prelude {
     pub use crate::error::CorrosionOrmError;
     pub use crate::model::repository::Repo;
     pub use crate::model::{CursorPaginator, Paginator};
+    pub use crate::model::{Lazy, LazyCollection};
     pub use crate::query::*;
     pub use crate::query::{
         Delete, Insert, Select, Update,

--- a/crates/corrosion-orm-core/src/model/lazy.rs
+++ b/crates/corrosion-orm-core/src/model/lazy.rs
@@ -1,0 +1,202 @@
+use crate::driver::error::DriverError;
+use crate::model::repository::Repo;
+
+use crate::{CorrosionOrmError, Executor, query::query_type::Value};
+
+pub enum LazyCondition {
+    ById(Value),
+}
+
+pub(crate) enum LazyStep<F> {
+    NotLoaded(Option<LazyCondition>),
+    Pending(F),
+    Loaded(F),
+}
+/// A lazy-loaded single relation (`HasOne` / `BelongsTo`).
+///
+/// `Lazy<F>` stores the related entity in three possible states:
+/// - `NotLoaded(Some(condition))`: not fetched yet, but has a load condition
+/// - `Pending(entity)`: in-memory value set via `Lazy::from_entity`
+/// - `Loaded(entity)`: fetched and cached
+///
+/// When an entity is read from the database, the `#[derive(Model)]`-generated
+/// `FromRow` implementation initializes `Lazy::new()` and sets
+/// `LazyCondition::ById` from the foreign-key column. Calling `load` fetches
+/// the relation once and caches it; calling `load` while `Pending` simply
+/// promotes the value to `Loaded` without a database round-trip.
+///
+/// Saving the owner uses `resolve_relation_id_value`:
+/// - `Pending(entity)` => save entity and use its primary key
+/// - `NotLoaded(ById(v))` => use `v` directly
+/// - `Loaded(entity)` => use the entity primary key
+///
+/// # Required derives
+/// - **Owner struct**: `#[derive(Model)]` with `#[HasOne]` or `#[BelongsTo]`
+///   on a `Lazy<Related>` field.
+/// - **Related struct (`F`)**: `#[derive(Model, Default, Clone)]`.
+///   `Model` provides `Repo`, `FromRow`, `TableSchema`, and `get_id`/`set_id`.
+///   `Default` is used by the generated `FromRow` to seed the relation and
+///   assign the foreign key. `Clone` is required by `save()` to cascade
+///   via `resolve_relation_id_value`.
+///
+/// # Examples
+/// Has-one:
+/// ``` rust,ignore
+///     #[derive(Model)]
+///     #[Table(name = "countries")]
+///     pub struct Country {
+///         #[Column(name = "id")]
+///         #[PrimaryKey]
+///         pub id: i32,
+///         #[HasOne]
+///         pub capital: Lazy<Capital>,
+///     }
+///
+///     #[derive(Model, Default, Clone)]
+///     #[Table(name = "capitals")]
+///     pub struct Capital {
+///         #[Column(name = "id")]
+///         #[PrimaryKey]
+///         pub id: i32,
+///         pub name: String,
+///     }
+///
+///     let country = Country {
+///         id: 1,
+///         capital: Lazy::from_entity(Capital { id: 2, name: "Warsaw".to_string() }),
+///     };
+///     country.save(&mut db).await?;
+///
+///     let mut fetched = Country::get_by_id(1, &mut db).await?.unwrap();
+///     let capital = fetched.capital.load(&mut db).await?;
+///     assert_eq!(capital.name, "Warsaw");
+///     ```
+/// Belongs-to:
+/// ``` rust,ignore
+///     #[derive(Model)]
+///     #[Table(name = "articles_lazy")]
+///     pub struct ArticleLazy {
+///         #[Column(name = "id")]
+///         #[PrimaryKey]
+///         pub id: i32,
+///         #[BelongsTo(foreign_key = "author_id", table = "authors_lazy")]
+///         pub author: Lazy<AuthorLazy>,
+///     }
+///
+///     #[derive(Model, Default, Clone)]
+///     #[Table(name = "authors_lazy")]
+///     pub struct AuthorLazy {
+///         #[Column(name = "id")]
+///         #[PrimaryKey]
+///         pub id: i32,
+///         pub name: String,
+///     }
+///
+///     let mut article = ArticleLazy::get_by_id(1, &mut db).await?.unwrap();
+///     let author = article.author.load(&mut db).await?;
+///     assert_eq!(author.name, "Alice");
+/// ```
+pub struct Lazy<F> {
+    step: LazyStep<F>,
+}
+
+impl<F> Default for Lazy<F> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<F> Lazy<F> {
+    pub fn new() -> Self {
+        Self {
+            step: LazyStep::NotLoaded(None),
+        }
+    }
+    pub fn from_entity(entity: F) -> Self {
+        Self {
+            step: LazyStep::Pending(entity),
+        }
+    }
+    /// Sets the condition required to load this relation later
+    pub fn set_condition(&mut self, condition: LazyCondition) {
+        if let LazyStep::NotLoaded(ref mut cond) = self.step {
+            *cond = Some(condition);
+        }
+    }
+}
+
+impl<F> Lazy<F> {
+    /// Used by generated save() for lazy HasOne/BelongsTo:
+    /// - Pending(entity) => save entity and return PK as Value
+    /// - NotLoaded(ById(v)) => use v directly
+    /// - Loaded(entity) => use entity PK
+    pub async fn resolve_relation_id_value<E, FMap>(
+        &self,
+        db: &mut E,
+        id_to_value: FMap,
+    ) -> Result<Option<Value>, CorrosionOrmError>
+    where
+        E: Executor,
+        F: Repo<E> + Send + Unpin + Clone,
+        F::PrimaryKey: From<Value>,
+        FMap: Fn(&F) -> Value,
+    {
+        match &self.step {
+            LazyStep::NotLoaded(Some(LazyCondition::ById(v))) => Ok(Some(v.clone())),
+            LazyStep::NotLoaded(None) => Ok(None),
+            LazyStep::Pending(entity) => {
+                let saved = entity.clone().save(db).await?;
+                Ok(Some(id_to_value(&saved)))
+            }
+            LazyStep::Loaded(entity) => Ok(Some(id_to_value(entity))),
+        }
+    }
+
+    pub async fn load<E: Executor>(&mut self, db: &mut E) -> Result<&mut F, CorrosionOrmError>
+    where
+        F: Repo<E>
+            + Send
+            + Unpin
+            + Clone
+            + for<'r> sqlx::FromRow<'r, sqlx::sqlite::SqliteRow>
+            + crate::schema::table::TableSchema,
+        F::PrimaryKey: From<Value>,
+    {
+        if let LazyStep::Loaded(ref mut f) = self.step {
+            return Ok(f);
+        }
+
+        if let LazyStep::Pending(_) = self.step
+            && let LazyStep::Pending(f) =
+                std::mem::replace(&mut self.step, LazyStep::NotLoaded(None))
+        {
+            self.step = LazyStep::Loaded(f);
+            if let LazyStep::Loaded(ref mut loaded) = self.step {
+                return Ok(loaded);
+            }
+        }
+
+        let loaded_entity = match &self.step {
+            LazyStep::NotLoaded(Some(condition)) => match condition {
+                LazyCondition::ById(id_val) => {
+                    let id = F::PrimaryKey::from(id_val.clone());
+                    F::get_by_id(id, db)
+                        .await?
+                        .ok_or(CorrosionOrmError::DriverError(DriverError::NotFound))?
+                }
+            },
+            LazyStep::NotLoaded(None) => {
+                return Err(CorrosionOrmError::DriverError(DriverError::NotFound));
+            }
+            LazyStep::Pending(_) | LazyStep::Loaded(_) => unreachable!(),
+        };
+
+        self.step = LazyStep::Loaded(loaded_entity);
+
+        if let LazyStep::Loaded(ref mut f) = self.step {
+            Ok(f)
+        } else {
+            unreachable!()
+        }
+    }
+}

--- a/crates/corrosion-orm-core/src/model/lazy_collection.rs
+++ b/crates/corrosion-orm-core/src/model/lazy_collection.rs
@@ -1,0 +1,156 @@
+use sqlx::FromRow;
+
+use crate::{
+    CorrosionOrmError, Executor,
+    driver::error::DriverError,
+    model::repository::Repo,
+    query::{WhereClause, query_type::Value},
+    schema::table::TableSchema,
+    types::ColumnTrait,
+};
+
+#[derive(Clone)]
+pub enum LazyCollectionCondition<C: ColumnTrait> {
+    ByForeignKey { fk_column: C, value: Value },
+    ByFilter(WhereClause<C>),
+}
+
+enum LazyCollectionStep<F, C: ColumnTrait> {
+    NotLoaded(Option<LazyCollectionCondition<C>>),
+    Pending(Vec<F>),
+    Loaded(Vec<F>),
+}
+
+/// A lazy-loaded collection for `HasMany` relations.
+///
+/// `LazyCollection<F, C>` stores three possible states:
+/// - `NotLoaded(Some(condition))`: not fetched yet, but has a load condition
+/// - `Pending(Vec<F>)`: in-memory value set via `LazyCollection::from_vec`
+/// - `Loaded(Vec<F>)`: fetched and cached
+///
+/// When an entity is read from the database, the `#[derive(Model)]`-generated
+/// `FromRow` implementation initializes `LazyCollection::new()` and sets a
+/// `LazyCollectionCondition::ByForeignKey` using the owner's primary key.
+/// Calling `load` fetches the collection once and caches it; calling `load`
+/// while `Pending` simply promotes the value to `Loaded` without hitting the DB.
+///
+/// Note: the generated `save()` does **not** cascade into lazy collections.
+/// If you need cascade saves, use an eager `Vec<Child>` relation or save
+/// children manually.
+///
+/// # Required derives
+/// - **Owner struct**: `#[derive(Model)]` with `#[HasMany(...)]` on a
+///   `LazyCollection<Child, child::Column>` field.
+/// - **Child struct (`F`)**: `#[derive(Model)]` so `Repo`, `FromRow`,
+///   `TableSchema`, and the `child::Column` enum are available.
+///
+/// # Example
+/// ``` rust,ignore
+///     #[derive(Model)]
+///     #[Table(name = "departments_lazy")]
+///     pub struct DepartmentLazy {
+///         #[Column(name = "id")]
+///         #[PrimaryKey]
+///         pub id: i32,
+///         #[HasMany(foreign_key = "department_id", table = "employees_lazy")]
+///         pub employees: LazyCollection<EmployeeLazy, employeelazy::Column>,
+///     }
+///
+///     #[derive(Model)]
+///     #[Table(name = "employees_lazy")]
+///     pub struct EmployeeLazy {
+///         #[Column(name = "id")]
+///         #[PrimaryKey]
+///         pub id: i32,
+///         #[Column(name = "department_id")]
+///         pub department_id: i32,
+///         pub name: String,
+///     }
+///
+///     let mut dept = DepartmentLazy::get_by_id(1, &mut db).await?.unwrap();
+///     let employees = dept.employees.load(&mut db).await?;
+///     assert_eq!(employees.len(), 2);
+/// ```
+pub struct LazyCollection<F, C: ColumnTrait> {
+    step: LazyCollectionStep<F, C>,
+}
+impl<F, C: ColumnTrait> Default for LazyCollection<F, C> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+impl<F, C: ColumnTrait> LazyCollection<F, C> {
+    pub fn new() -> Self {
+        Self {
+            step: LazyCollectionStep::NotLoaded(None),
+        }
+    }
+
+    pub fn with_condition(condition: LazyCollectionCondition<C>) -> Self {
+        Self {
+            step: LazyCollectionStep::NotLoaded(Some(condition)),
+        }
+    }
+
+    pub fn from_vec(vec: Vec<F>) -> Self {
+        Self {
+            step: LazyCollectionStep::Pending(vec),
+        }
+    }
+
+    pub fn set_condition(&mut self, condition: LazyCollectionCondition<C>) {
+        if let LazyCollectionStep::NotLoaded(ref mut cond) = self.step {
+            *cond = Some(condition);
+        }
+    }
+
+    pub async fn load<E: Executor>(&mut self, db: &mut E) -> Result<&mut Vec<F>, CorrosionOrmError>
+    where
+        F: Repo<E, Column = C>
+            + Send
+            + Unpin
+            + TableSchema
+            + for<'r> FromRow<'r, sqlx::sqlite::SqliteRow>,
+    {
+        if let LazyCollectionStep::Loaded(ref mut items) = self.step {
+            return Ok(items);
+        }
+
+        if let LazyCollectionStep::Pending(_) = self.step
+            && let LazyCollectionStep::Pending(items) =
+                std::mem::replace(&mut self.step, LazyCollectionStep::NotLoaded(None))
+        {
+            self.step = LazyCollectionStep::Loaded(items);
+            if let LazyCollectionStep::Loaded(ref mut loaded) = self.step {
+                return Ok(loaded);
+            }
+        }
+
+        let loaded_items = match &self.step {
+            LazyCollectionStep::NotLoaded(Some(LazyCollectionCondition::ByForeignKey {
+                fk_column,
+                value,
+            })) => {
+                F::find()
+                    .filter(WhereClause::eq(*fk_column, value.clone()))
+                    .all(db)
+                    .await?
+            }
+            LazyCollectionStep::NotLoaded(Some(LazyCollectionCondition::ByFilter(filter))) => {
+                F::find().filter(filter.clone()).all(db).await?
+            }
+            LazyCollectionStep::NotLoaded(None) => {
+                return Err(CorrosionOrmError::DriverError(DriverError::NotFound));
+            }
+            LazyCollectionStep::Pending(_) | LazyCollectionStep::Loaded(_) => unreachable!(),
+        };
+
+        self.step = LazyCollectionStep::Loaded(loaded_items);
+
+        if let LazyCollectionStep::Loaded(ref mut items) = self.step {
+            Ok(items)
+        } else {
+            unreachable!()
+        }
+    }
+}

--- a/crates/corrosion-orm-core/src/model/mod.rs
+++ b/crates/corrosion-orm-core/src/model/mod.rs
@@ -1,9 +1,13 @@
 //! Repository trait for database operations on entities.
 pub mod cursor_paginator;
 pub mod finder;
+pub mod lazy;
+pub mod lazy_collection;
 pub mod paginator;
 pub mod repository;
 
 pub use cursor_paginator::CursorPaginator;
 pub use finder::Finder;
+pub use lazy::Lazy;
+pub use lazy_collection::LazyCollection;
 pub use paginator::Paginator;

--- a/crates/corrosion-orm-core/src/query/query_type.rs
+++ b/crates/corrosion-orm-core/src/query/query_type.rs
@@ -10,6 +10,7 @@ pub enum Value {
     Bool(bool),
     Date(chrono::NaiveDate),
     DateTime(chrono::NaiveDateTime),
+    Null,
 }
 
 macro_rules! impl_from_value {
@@ -55,12 +56,11 @@ impl From<chrono::NaiveDateTime> for Value {
 impl<T> From<Option<T>> for Value
 where
     Value: From<T>,
-    T: Default,
 {
     fn from(v: Option<T>) -> Self {
         match v {
             Some(inner) => Value::from(inner),
-            None => Value::from(T::default()),
+            None => Value::Null,
         }
     }
 }
@@ -94,6 +94,7 @@ impl QueryContext {
                     Value::Bool(b) => if *b { "1" } else { "0" }.to_string(),
                     Value::Date(d) => format!("'{}'", d),
                     Value::DateTime(naive_date_time) => format!("'{}'", naive_date_time),
+                    Value::Null => "NULL".to_string(),
                 };
                 sql.replace_range(pos..pos + placeholder.len(), &value_str);
             }
@@ -156,6 +157,25 @@ impl From<&str> for QueryContext {
             sql: sql.to_string(),
             values: Vec::new(),
             placeholder_count: 0,
+        }
+    }
+}
+impl From<Value> for i32 {
+    fn from(v: Value) -> Self {
+        match v {
+            Value::Int(i) => i,
+            Value::Int64(i) => i as i32,
+            _ => panic!("Cannot convert Value to i32"),
+        }
+    }
+}
+
+impl From<Value> for i64 {
+    fn from(v: Value) -> Self {
+        match v {
+            Value::Int(i) => i as i64,
+            Value::Int64(i) => i,
+            _ => panic!("Cannot convert Value to i64"),
         }
     }
 }

--- a/crates/corrosion-orm-core/src/query/select.rs
+++ b/crates/corrosion-orm-core/src/query/select.rs
@@ -313,11 +313,12 @@ impl<'col, C: ColumnTrait> From<&'col TableSchemaModel> for Select<'col, C> {
                     .relations
                     .iter()
                     .filter(|r| {
-                        matches!(
-                            r.relation_type,
-                            crate::schema::relation::RelationType::HasOne
-                                | crate::schema::relation::RelationType::BelongsTo
-                        )
+                        r.is_eager
+                            && matches!(
+                                r.relation_type,
+                                crate::schema::relation::RelationType::HasOne
+                                    | crate::schema::relation::RelationType::BelongsTo
+                            )
                     })
                     .filter_map(|r| Join::from_relation(r).ok())
                     .collect(),

--- a/crates/corrosion-orm-core/src/schema/relation.rs
+++ b/crates/corrosion-orm-core/src/schema/relation.rs
@@ -18,53 +18,88 @@ pub struct RelationModel {
     pub field: ColumnSchemaModel,
     /// The table where the foreign key column exists
     pub source_table: String,
+    /// Whether this relation should be eager-loaded by default.
+    pub is_eager: bool,
 }
 
 impl RelationModel {
-    /// Creates a RelationModel from the provided relation metadata.
+    /// Creates a `RelationBuilder` used to construct a `RelationModel`.
     ///
-    /// The returned model stores the relation kind, related table and key names,
-    /// relation name, the source table, and the associated column schema.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use corrosion_orm_core::schema::{relation::RelationModel, relation::RelationType, table::ColumnSchemaModel};
-    /// use corrosion_orm_core::types::column_type::SqlType;
-    ///
-    /// let field = ColumnSchemaModel {
-    ///     name: "user_id".to_string(),
-    ///     is_nullable: false,
-    ///     is_unique: false,
-    ///     sql_type: SqlType::Integer,
-    /// };
-    /// let rel = RelationModel::new(
-    ///     RelationType::HasOne,
-    ///     "profiles".to_string(),
-    ///     "user_id".to_string(),
-    ///     "id".to_string(),
-    ///     "profile".to_string(),
-    ///     "users".to_string(),
-    ///     field,
-    /// );
-    /// ```
-    pub fn new(
-        relation_type: RelationType,
-        table: String,
-        foreign_key: String,
-        target_key: String,
-        relation_name: String,
-        source_table: String,
-        field: ColumnSchemaModel,
-    ) -> Self {
-        Self {
-            relation_type,
-            table,
-            foreign_key,
-            target_key,
-            relation_name,
-            source_table,
-            field,
+    /// Prefer the builder to avoid long argument lists and improve call-site
+    /// readability.
+    pub fn builder() -> RelationBuilder {
+        RelationBuilder::default()
+    }
+}
+
+/// Builder for `RelationModel`.
+#[derive(Debug, Clone, Default)]
+pub struct RelationBuilder {
+    relation_type: Option<RelationType>,
+    table: Option<String>,
+    foreign_key: Option<String>,
+    target_key: Option<String>,
+    relation_name: Option<String>,
+    field: Option<ColumnSchemaModel>,
+    /// The table where the foreign key column exists
+    source_table: Option<String>,
+    /// Whether this relation should be eager-loaded by default.
+    is_eager: Option<bool>,
+}
+
+impl RelationBuilder {
+    pub fn relation_type(mut self, t: RelationType) -> Self {
+        self.relation_type = Some(t);
+        self
+    }
+
+    pub fn table<S: Into<String>>(mut self, s: S) -> Self {
+        self.table = Some(s.into());
+        self
+    }
+
+    pub fn foreign_key<S: Into<String>>(mut self, s: S) -> Self {
+        self.foreign_key = Some(s.into());
+        self
+    }
+
+    pub fn target_key<S: Into<String>>(mut self, s: S) -> Self {
+        self.target_key = Some(s.into());
+        self
+    }
+
+    pub fn relation_name<S: Into<String>>(mut self, s: S) -> Self {
+        self.relation_name = Some(s.into());
+        self
+    }
+
+    pub fn field(mut self, f: ColumnSchemaModel) -> Self {
+        self.field = Some(f);
+        self
+    }
+
+    pub fn source_table<S: Into<String>>(mut self, s: S) -> Self {
+        self.source_table = Some(s.into());
+        self
+    }
+
+    pub fn is_eager(mut self, b: bool) -> Self {
+        self.is_eager = Some(b);
+        self
+    }
+
+    /// Build the `RelationModel`, consuming the builder. Panics if required fields
+    /// are missing.
+    pub fn build(self) -> RelationModel {
+        RelationModel {
+            relation_type: self.relation_type.expect("relation_type is required"),
+            table: self.table.expect("table is required"),
+            foreign_key: self.foreign_key.expect("foreign_key is required"),
+            target_key: self.target_key.expect("target_key is required"),
+            relation_name: self.relation_name.expect("relation_name is required"),
+            field: self.field.expect("field is required"),
+            source_table: self.source_table.expect("source_table is required"),
+            is_eager: self.is_eager.unwrap_or(false),
         }
     }
 }

--- a/crates/corrosion-orm-macros/src/generator/from_row_generate.rs
+++ b/crates/corrosion-orm-macros/src/generator/from_row_generate.rs
@@ -1,12 +1,13 @@
+use crate::utils::extract_type_ident;
 use crate::{
     TableData,
     model::{Field, primary_key::PrimaryKeyField},
+    utils::extract_inner_type,
 };
 use corrosion_orm_core::schema::relation::RelationType;
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::Type;
-
 /// Generate a Rust `TokenStream` that implements `sqlx::FromRow` for the provided table struct.
 ///
 /// The generated implementation constructs the struct by reading the primary key and each
@@ -26,9 +27,10 @@ use syn::Type;
 /// ```
 pub(crate) fn generate_from_row(table: &TableData) -> TokenStream {
     let struct_ident = &table.ident;
+    let owner_pk_name = &table.primary_key.name;
+    let owner_pk_ty = &table.primary_key.ty;
 
     let pk_field_assign = generate_pk_field_assign(&table.primary_key);
-    // Note: table.fields already excludes the PK and relation fields (they are parsed separately)
     let field_assigns: Vec<TokenStream> = table.fields.iter().map(generate_field_assign).collect();
 
     let relation_field_assigns: Vec<TokenStream> = table
@@ -38,26 +40,72 @@ pub(crate) fn generate_from_row(table: &TableData) -> TokenStream {
             let field_name = syn::Ident::new(&rel.relation_name, proc_macro2::Span::call_site());
             let rel_ty = &rel.ty;
             let fk_name = &rel.foreign_key;
+            let fk_column_ident = syn::Ident::new(fk_name, proc_macro2::Span::call_site());
+
+
             match rel.relation_type {
-                RelationType::BelongsTo => {
-                    // For BelongsTo, read the FK column from the row and populate the
-                    // related entity's primary key so that load_relations can fetch it.
-                    quote! {
-                        #field_name: {
-                            let mut rel = #rel_ty::default();
-                            rel.set_id(row.try_get(#fk_name)?);
-                            rel
-                        },
+                RelationType::BelongsTo | RelationType::HasOne => {
+                    if !rel.is_eager {
+                        let related_ty = extract_inner_type(rel_ty);
+                        quote! {
+                            #field_name: {
+                                let mut lazy: #rel_ty = corrosion_orm_core::model::lazy::Lazy::new();
+                                let mut rel = <#related_ty>::default();
+                                rel.set_id(row.try_get(#fk_name)?);
+
+                                lazy.set_condition(
+                                    corrosion_orm_core::model::lazy::LazyCondition::ById(
+                                        corrosion_orm_core::query::query_type::Value::from(rel.get_id())
+                                    )
+                                );
+                                lazy
+                            },
+                        }
+                    } else {
+                        quote! {
+                            #field_name: {
+                                let mut rel = #rel_ty::default();
+                                rel.set_id(row.try_get(#fk_name)?);
+                                rel
+                            },
+                        }
                     }
                 }
-                _ => {
-                    quote! {
-                        #field_name: Default::default(),
+
+                RelationType::HasMany => {
+                    if !rel.is_eager {
+                        let child_ty = extract_inner_type(rel_ty);
+                        let child_ident = extract_type_ident(&child_ty)
+                            .expect("HasMany relation inner type must be a path type");
+                        let child_mod = syn::Ident::new(
+                            &child_ident.to_string().to_lowercase(),
+                            proc_macro2::Span::call_site(),
+                        );
+                        quote! {
+                            #field_name: {
+                                let mut lazy: #rel_ty = corrosion_orm_core::model::lazy_collection::LazyCollection::new();
+                                let owner_id: #owner_pk_ty = row.try_get(#owner_pk_name)?;
+                                lazy.set_condition(
+                                    corrosion_orm_core::model::lazy_collection::LazyCollectionCondition::ByForeignKey {
+                                        fk_column: #child_mod::Column::#fk_column_ident,
+                                        value: corrosion_orm_core::query::query_type::Value::from(owner_id),
+                                    }
+                                );
+                                lazy
+                            },
+                        }
+                    } else {
+                        quote! { #field_name: Default::default(), }
                     }
                 }
+
+                _ => quote! {
+                    #field_name: Default::default(),
+                },
             }
         })
         .collect();
+
     let pk_bound = type_bounds(&table.primary_key.ty);
     let field_bounds: Vec<TokenStream> = table.fields.iter().map(|f| type_bounds(&f.ty)).collect();
 

--- a/crates/corrosion-orm-macros/src/generator/repository_generate.rs
+++ b/crates/corrosion-orm-macros/src/generator/repository_generate.rs
@@ -84,6 +84,7 @@ pub(crate) fn generate_repository(table: &TableData) -> proc_macro2::TokenStream
         syn::Ident::new(&table.primary_key.name, proc_macro2::Span::call_site());
 
     let mut relation_values_push = Vec::new();
+    let mut lazy_relation_values_push = Vec::new();
     let mut load_relations_impl = Vec::new();
     let mut cascade_save_before_impl = Vec::new();
     let mut cascade_save_after_impl = Vec::new();
@@ -97,6 +98,25 @@ pub(crate) fn generate_repository(table: &TableData) -> proc_macro2::TokenStream
         let rel_ty = &rel.ty;
         let fk_name_str = &rel.foreign_key;
         let fk_column = syn::Ident::new(fk_name_str, proc_macro2::Span::call_site());
+
+        if !rel.is_eager {
+            match rel.relation_type {
+                RelationType::HasOne | RelationType::BelongsTo => {
+                    lazy_relation_values_push.push(quote! {
+                        let rel_value = self.#rel_ident
+                            .resolve_relation_id_value(
+                                db,
+                                |e| corrosion_orm_core::query::query_type::Value::from(e.get_id())
+                            )
+                            .await?
+                            .ok_or(corrosion_orm_core::driver::error::DriverError::NotFound)?;
+                        values.push(rel_value);
+                    });
+                }
+                RelationType::HasMany | RelationType::BelongsToMany => {}
+            }
+            continue;
+        }
 
         match rel.relation_type {
             RelationType::HasOne | RelationType::BelongsTo => {
@@ -170,7 +190,10 @@ pub(crate) fn generate_repository(table: &TableData) -> proc_macro2::TokenStream
 
     quote! {
         impl #ident {
-            fn get_values_from_self(&self) -> Vec<corrosion_orm_core::query::query_type::Value> {
+            async fn get_values_from_self_with_db<Db: corrosion_orm_core::driver::executor::Executor>(
+                &self,
+                db: &mut Db,
+            ) -> Result<Vec<corrosion_orm_core::query::query_type::Value>, corrosion_orm_core::error::CorrosionOrmError> {
                 let mut values = Vec::new();
                 values.push(corrosion_orm_core::query::query_type::Value::from(self.#pk_ident.clone()));
                 #(
@@ -179,7 +202,9 @@ pub(crate) fn generate_repository(table: &TableData) -> proc_macro2::TokenStream
 
                 #(#relation_values_push)*
 
-                values
+                #(#lazy_relation_values_push)*
+
+                Ok(values)
             }
 
             /// Returns the strongly-typed primary key for this entity
@@ -226,15 +251,15 @@ pub(crate) fn generate_repository(table: &TableData) -> proc_macro2::TokenStream
                 let existing = db.fetch_optional::<Self>(&mut ctx_control).await?;
 
                 let mut ctx = QueryContext::new();
-
+                let values = self.get_values_from_self_with_db(db).await?;
                 if existing.is_none() {
                     let mut insert_query = corrosion_orm_core::query::insert::Insert::from(&schema)
-                        .values(self.get_values_from_self());
+                        .values(values);
                     insert_query.to_sql(&mut ctx, db.get_dialect());
                     db.execute_query(&mut ctx).await?;
                 } else {
                     let mut update_query = corrosion_orm_core::query::update::Update::<#mod_name::Column>::from(&schema)
-                        .values(self.get_values_from_self())
+                        .values(values)
                         .where_clause(WhereClause::eq(#mod_name::Column::#pk_column_variant, self.#pk_ident.clone()));
                     update_query.to_sql(&mut ctx, db.get_dialect());
                     db.execute_query(&mut ctx).await?;

--- a/crates/corrosion-orm-macros/src/generator/schema_generate.rs
+++ b/crates/corrosion-orm-macros/src/generator/schema_generate.rs
@@ -2,45 +2,11 @@ use crate::TableData;
 use crate::model::Field;
 use crate::model::primary_key::PrimaryKeyField;
 use crate::model::relation::RelationDefinition;
+use crate::utils::extract_inner_type;
 use corrosion_orm_core::schema::relation::RelationType;
 use corrosion_orm_core::types::generation_strategy::GenerationType;
 use proc_macro2::TokenStream;
 use quote::quote;
-
-/// Extracts the inner type `T` from a `Vec<T>` `syn::Type`, or returns the original type unchanged.
-///
-/// If `ty` is a path type whose last segment is `Vec` with a single generic type argument, this
-/// function returns a clone of that inner type. For any other `syn::Type` it returns a clone of
-/// `ty`.
-///
-/// # Examples
-///
-/// ```ignore
-/// use syn::Type;
-/// use quote::ToTokens;
-///
-/// // Vec inner type is extracted
-/// let vec_ty: Type = syn::parse_str("Vec<i32>").unwrap();
-/// let inner = extract_vec_inner_type(&vec_ty);
-/// assert_eq!(inner.to_token_stream().to_string(), "i32");
-///
-/// // Non-Vec types are returned unchanged (cloned)
-/// let simple_ty: Type = syn::parse_str("String").unwrap();
-/// let same = extract_vec_inner_type(&simple_ty);
-/// assert_eq!(same.to_token_stream().to_string(), "String");
-/// ```
-fn extract_vec_inner_type(ty: &syn::Type) -> syn::Type {
-    if let syn::Type::Path(type_path) = ty
-        && let Some(segment) = type_path.path.segments.last()
-        && segment.ident == "Vec"
-        && let syn::PathArguments::AngleBracketed(args) = &segment.arguments
-        && let Some(syn::GenericArgument::Type(inner_ty)) = args.args.first()
-    {
-        return inner_ty.clone();
-    }
-
-    ty.clone()
-}
 
 /// Generate a TokenStream that implements the TableSchema trait for the provided table definition.
 ///
@@ -199,28 +165,14 @@ fn generate_relation(
     let key = &relation.foreign_key;
     let relation_name = &relation.relation_name;
     let field_type = &relation.ty;
+    let is_eager = relation.is_eager;
     let is_unique = match &relation.relation_type {
         RelationType::HasOne => true,
         RelationType::HasMany | RelationType::BelongsTo | RelationType::BelongsToMany => false,
     };
 
-    let check_type = if matches!(
-        relation.relation_type,
-        RelationType::HasMany | RelationType::BelongsToMany
-    ) {
-        extract_vec_inner_type(field_type)
-    } else {
-        field_type.clone()
-    };
-
-    let table_expr_type = if matches!(
-        relation.relation_type,
-        RelationType::HasMany | RelationType::BelongsToMany
-    ) {
-        &check_type
-    } else {
-        field_type
-    };
+    let check_type = extract_inner_type(field_type);
+    let table_expr_type = &check_type;
 
     let table_expr = match &relation.table {
         Some(t) => quote! { String::from(#t) },
@@ -249,20 +201,21 @@ fn generate_relation(
         };
     };
     let relation = quote! {
-        corrosion_orm_core::schema::relation::RelationModel::new(
-            #ty,
-            #table_expr,
-            String::from(#key),
-            <#check_type as corrosion_orm_core::schema::table::TableSchema>::get_schema().primary_key.name,
-            String::from(#relation_name),
-            String::from(#source_table),
-            corrosion_orm_core::schema::table::ColumnSchemaModel {
+        corrosion_orm_core::schema::relation::RelationModel::builder()
+            .relation_type(#ty)
+            .table(#table_expr)
+            .foreign_key(String::from(#key))
+            .target_key(<#check_type as corrosion_orm_core::schema::table::TableSchema>::get_schema().primary_key.name)
+            .relation_name(String::from(#relation_name))
+            .source_table(String::from(#source_table))
+            .is_eager(#is_eager)
+            .field(corrosion_orm_core::schema::table::ColumnSchemaModel {
                 name: String::from(#key),
                 is_nullable: false,
                 is_unique: #is_unique,
                 sql_type: <#check_type as corrosion_orm_core::schema::table::TableSchema>::get_schema().primary_key.ty
-            },
-        )
+            })
+            .build()
     };
     (check, relation)
 }

--- a/crates/corrosion-orm-macros/src/model/parser.rs
+++ b/crates/corrosion-orm-macros/src/model/parser.rs
@@ -3,10 +3,10 @@ use crate::model::{
     primary_key::{PrimaryKeyAttribute, PrimaryKeyField},
     relation::{BelongsToAttribute, HasManyAttribute, HasOneAttribute, RelationDefinition},
 };
+use crate::utils::type_is_ident;
 use corrosion_orm_core::schema::relation::RelationType;
 use std::collections::HashSet;
 use syn::{DeriveInput, Fields, spanned::Spanned};
-
 /// Builds a TableData value from a derive-input struct by extracting table metadata, columns, the single primary key, indexes (table- and field-level), and relation definitions.
 ///
 /// Returns a populated `TableData` containing `ident`, resolved `name`, parsed `fields`, the required `primary_key`, normalized `indexes`, and any `relations` discovered on fields. Errors if the input is not a struct, if no field is marked with `#[PrimaryKey]`, if index names collide, or if attribute/field parsing fails; such errors are returned as `syn::Error`.
@@ -118,6 +118,10 @@ macro_rules! parse_relation {
             let foreign_key = attr
                 .foreign_key
                 .unwrap_or_else(|| format!("{}_id", $field.ident.as_ref().unwrap()));
+            let mut is_eager = true;
+            if type_is_ident(&$field.ty, "Lazy") || type_is_ident(&$field.ty, "LazyCollection") {
+                is_eager = false;
+            }
             $relations.push(RelationDefinition {
                 relation_type: RelationType::$variant,
                 table: attr.table,
@@ -125,6 +129,7 @@ macro_rules! parse_relation {
                 relation_name: $field_name.clone(),
                 ty: $field.ty.clone(),
                 ident: $field.ident.clone().unwrap(),
+                is_eager,
             });
             continue;
         }
@@ -185,6 +190,7 @@ fn parse_fields(
             primary_key = Some(PrimaryKeyField::from((&col_attr, pk_attr, &*field)));
             continue;
         }
+
         parse_relation!(HasOne, HasOneAttribute, field, relations, field_name);
         parse_relation!(HasMany, HasManyAttribute, field, relations, field_name);
         parse_relation!(BelongsTo, BelongsToAttribute, field, relations, field_name);
@@ -509,6 +515,42 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("Field must be named")
+        );
+    }
+    #[test]
+    fn lazy_relation() {
+        let mut input: DeriveInput = parse_quote! {
+            #[Table(name = "users")]
+            struct User {
+                #[Column(name = "id")]
+                #[PrimaryKey]
+                id: i32,
+                #[HasOne]
+                email: Lazy<User>,
+            }
+        };
+        let table = parse_model(&mut input).unwrap();
+        assert!(
+            !table.relations.first().unwrap().is_eager,
+            "is_eager must be false"
+        );
+    }
+    #[test]
+    fn eager_relation() {
+        let mut input: DeriveInput = parse_quote! {
+            #[Table(name = "users")]
+            struct User {
+                #[Column(name = "id")]
+                #[PrimaryKey]
+                id: i32,
+                #[HasOne]
+                email: User,
+            }
+        };
+        let table = parse_model(&mut input).unwrap();
+        assert!(
+            table.relations.first().unwrap().is_eager,
+            "is_eager must be true"
         );
     }
 }

--- a/crates/corrosion-orm-macros/src/model/relation.rs
+++ b/crates/corrosion-orm-macros/src/model/relation.rs
@@ -37,4 +37,5 @@ pub struct RelationDefinition {
     pub relation_name: String,
     pub ty: syn::Type,
     pub ident: Ident,
+    pub is_eager: bool,
 }

--- a/crates/corrosion-orm-macros/src/utils/mod.rs
+++ b/crates/corrosion-orm-macros/src/utils/mod.rs
@@ -1,4 +1,4 @@
-use syn::Type;
+use syn::{Type, TypePath};
 
 pub(crate) fn is_option_type(ty: &Type) -> bool {
     if let Type::Path(type_path) = ty
@@ -7,4 +7,64 @@ pub(crate) fn is_option_type(ty: &Type) -> bool {
         return segment.ident == "Option";
     }
     false
+}
+pub fn type_is_ident(ty: &Type, name: &str) -> bool {
+    let ty = strip_wrappers(ty);
+    match ty {
+        Type::Path(TypePath { qself: None, path }) => path
+            .segments
+            .last()
+            .map(|seg| seg.ident == name)
+            .unwrap_or(false),
+        _ => false,
+    }
+}
+fn strip_wrappers(mut ty: &Type) -> &Type {
+    loop {
+        match ty {
+            Type::Reference(r) => ty = &*r.elem,
+            Type::Paren(p) => ty = &*p.elem,
+            Type::Group(g) => ty = &*g.elem,
+            _ => break,
+        }
+    }
+    ty
+}
+/// Extracts the inner type `T` from a `syn::Type` if it is a `syn::Type::Path`.
+/// Otherwise, returns the original type unchanged.
+/// # Examples
+///
+/// ```ignore
+/// use syn::Type;
+/// use quote::ToTokens;
+///
+/// // Vec inner type is extracted
+/// let vec_ty: Type = syn::parse_str("Vec<i32>").unwrap();
+/// let inner = extract_inner_type(&vec_ty);
+/// assert_eq!(inner.to_token_stream().to_string(), "i32");
+///
+/// // Non-Vec types are returned unchanged (cloned)
+/// let simple_ty: Type = syn::parse_str("String").unwrap();
+/// let same = extract_inner_type(&simple_ty);
+/// assert_eq!(same.to_token_stream().to_string(), "String");
+/// ```
+pub fn extract_inner_type(ty: &syn::Type) -> syn::Type {
+    if let syn::Type::Path(type_path) = ty
+        && let Some(segment) = type_path.path.segments.last()
+        && let syn::PathArguments::AngleBracketed(args) = &segment.arguments
+        && let Some(syn::GenericArgument::Type(inner_ty)) = args.args.first()
+    {
+        return inner_ty.clone();
+    }
+
+    ty.clone()
+}
+
+pub fn extract_type_ident(ty: &Type) -> Option<syn::Ident> {
+    if let Type::Path(type_path) = ty
+        && let Some(segment) = type_path.path.segments.last()
+    {
+        return Some(segment.ident.clone());
+    }
+    None
 }

--- a/crates/corrosion-orm-test/src/query/insert_tests.rs
+++ b/crates/corrosion-orm-test/src/query/insert_tests.rs
@@ -169,4 +169,19 @@ mod tests {
         let (sql, _) = render_insert(insert);
         insta::assert_snapshot!(sql, @"INSERT INTO users (id, name) VALUES(?, ?)");
     }
+    #[test]
+    fn test_insert_with_option_none() {
+        let insert = Insert::new("users")
+            .columns(vec![Cow::Borrowed("username"), Cow::Borrowed("nickname")])
+            .values(vec![
+                Value::String("john_doe".to_string()),
+                Value::from(Option::<String>::None),
+            ]);
+        let mut ctx = QueryContext::new();
+        insert.to_sql(&mut ctx, &MockSqliteDialect);
+        let sql = ctx.to_debug_sql(&MockSqliteDialect);
+        insta::assert_snapshot!(sql, @"INSERT INTO users (username, nickname) VALUES('john_doe', NULL)");
+        assert_eq!(ctx.values.len(), 2);
+        assert_eq!(ctx.values[1], Value::Null);
+    }
 }

--- a/crates/corrosion-orm-test/src/repository_test/relation_test.rs
+++ b/crates/corrosion-orm-test/src/repository_test/relation_test.rs
@@ -1,10 +1,16 @@
 #[cfg(test)]
 mod tests {
+
     use crate::{
         init_sqlite,
         test_entities::{Post, Teacher, User},
     };
-    use corrosion_orm_core::prelude::*;
+    use corrosion_orm_core::{
+        SqliteDriver,
+        model::{lazy::Lazy, lazy_collection::LazyCollection},
+        prelude::*,
+    };
+    use corrosion_orm_macros::Model;
 
     /// Helper to count rows in users table
     async fn count_users(conn: &mut impl Executor) -> Result<i64, CorrosionOrmError> {
@@ -740,6 +746,190 @@ mod tests {
         let final_teacher = Teacher::get_by_id(1, &mut conn).await?.unwrap();
         assert_eq!(final_teacher.posts.len(), 3);
         assert_eq!(count_posts(&mut conn).await?, 3);
+
+        Ok(())
+    }
+    #[derive(Model)]
+    #[Table(name = "countries")]
+    #[Index(name = "idx_countries_id", fields = ["id"], unique = true)]
+    pub struct Country {
+        #[Column(name = "id")]
+        #[PrimaryKey]
+        #[allow(unused)]
+        pub id: i32,
+        #[HasOne]
+        pub capital: Lazy<Capital>,
+    }
+
+    #[derive(Model, Default, Clone)]
+    pub struct Capital {
+        #[Column(name = "id")]
+        #[PrimaryKey]
+        pub id: i32,
+        pub name: String,
+    }
+    async fn init_schemas(schemas: Vec<TableSchemaModel>, driver: &mut SqliteDriver) {
+        for schema in schemas {
+            let mut ctx = QueryContext::from_model(
+                schema,
+                driver.acquire_conn().await.unwrap().get_dialect(),
+            );
+            driver
+                .acquire_conn()
+                .await
+                .unwrap()
+                .execute_query(&mut ctx)
+                .await
+                .unwrap();
+        }
+    }
+    #[tokio::test]
+    async fn test_lazy_fetch() -> Result<(), CorrosionOrmError> {
+        let mut driver = init_sqlite().await;
+        init_schemas(
+            vec![Capital::get_schema(), Country::get_schema()],
+            &mut driver,
+        )
+        .await;
+        let mut conn = driver.acquire_conn().await?;
+        let country = Country {
+            id: 1,
+            capital: Lazy::from_entity(Capital {
+                id: 2,
+                name: String::from("Warsaw"),
+            }),
+        };
+        country.save(&mut conn).await?;
+        let mut fetched_country = Country::get_by_id(1, &mut conn).await?.unwrap();
+        assert_eq!(
+            fetched_country.capital.load(&mut conn).await?.name,
+            String::from("Warsaw")
+        );
+        Ok(())
+    }
+    #[derive(Model)]
+    #[Table(name = "articles_lazy")]
+    pub struct ArticleLazy {
+        #[Column(name = "id")]
+        #[PrimaryKey]
+        pub id: i32,
+        #[BelongsTo(foreign_key = "author_id", table = "authors_lazy")]
+        pub author: Lazy<AuthorLazy>,
+    }
+
+    #[derive(Model, Default, Clone)]
+    #[Table(name = "authors_lazy")]
+    pub struct AuthorLazy {
+        #[Column(name = "id")]
+        #[PrimaryKey]
+        pub id: i32,
+        #[Column(name = "name")]
+        pub name: String,
+    }
+
+    #[derive(Model)]
+    #[Table(name = "departments_lazy")]
+    pub struct DepartmentLazy {
+        #[Column(name = "id")]
+        #[PrimaryKey]
+        pub id: i32,
+        #[HasMany(foreign_key = "department_id", table = "employees_lazy")]
+        pub employees: LazyCollection<EmployeeLazy, employeelazy::Column>,
+    }
+
+    #[derive(Model, Default, Clone)]
+    #[Table(name = "employees_lazy")]
+    pub struct EmployeeLazy {
+        #[Column(name = "id")]
+        #[PrimaryKey]
+        pub id: i32,
+        #[Column(name = "department_id")]
+        pub department_id: i32,
+        #[Column(name = "name")]
+        pub name: String,
+    }
+
+    #[tokio::test]
+    async fn test_lazy_fetch_belongs_to() -> Result<(), CorrosionOrmError> {
+        let mut driver = init_sqlite().await;
+        init_schemas(
+            vec![AuthorLazy::get_schema(), ArticleLazy::get_schema()],
+            &mut driver,
+        )
+        .await;
+
+        let mut conn = driver.acquire_conn().await?;
+
+        let article = ArticleLazy {
+            id: 1,
+            author: Lazy::from_entity(AuthorLazy {
+                id: 10,
+                name: "Alice".to_string(),
+            }),
+        };
+
+        article.save(&mut conn).await?;
+
+        let mut fetched = ArticleLazy::get_by_id(1, &mut conn).await?.unwrap();
+        let author = fetched.author.load(&mut conn).await?;
+
+        assert_eq!(author.id, 10);
+        assert_eq!(author.name, "Alice");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_lazy_fetch_has_many() -> Result<(), CorrosionOrmError> {
+        let schema = DepartmentLazy::get_schema();
+        let rel = schema
+            .relations
+            .iter()
+            .find(|r| r.relation_name == "employees")
+            .unwrap();
+        assert!(matches!(
+            rel.relation_type,
+            corrosion_orm_core::schema::relation::RelationType::HasMany
+        ));
+        assert!(!rel.is_eager, "employees relation should be lazy");
+
+        let mut driver = init_sqlite().await;
+        init_schemas(
+            vec![EmployeeLazy::get_schema(), DepartmentLazy::get_schema()],
+            &mut driver,
+        )
+        .await;
+
+        let mut conn = driver.acquire_conn().await?;
+
+        let department = DepartmentLazy {
+            id: 1,
+            employees: LazyCollection::new(),
+        };
+        department.save(&mut conn).await?;
+
+        EmployeeLazy {
+            id: 1,
+            department_id: 1,
+            name: "Emp One".to_string(),
+        }
+        .save(&mut conn)
+        .await?;
+
+        EmployeeLazy {
+            id: 2,
+            department_id: 1,
+            name: "Emp Two".to_string(),
+        }
+        .save(&mut conn)
+        .await?;
+
+        let mut fetched = DepartmentLazy::get_by_id(1, &mut conn).await?.unwrap();
+        let employees = fetched.employees.load(&mut conn).await?;
+
+        assert_eq!(employees.len(), 2);
+        assert!(employees.iter().any(|e| e.id == 1 && e.department_id == 1));
+        assert!(employees.iter().any(|e| e.id == 2 && e.department_id == 1));
 
         Ok(())
     }


### PR DESCRIPTION
This pull request introduces support for lazy loading of entity relations in the ORM core, allowing related entities and collections to be loaded from the database only when accessed. It also adds a new `Null` variant to the `Value` type to better represent SQL nulls, and refactors relation metadata to use a builder pattern and support eager/lazy loading. These changes improve flexibility and efficiency for handling database relations and queries.

**Lazy loading support:**

* Introduced `Lazy<F>` for lazy-loaded single relations (`HasOne`/`BelongsTo`) and `LazyCollection<F, C>` for lazy-loaded collections (`HasMany`), including their state management, loading logic, and documentation. [[1]](diffhunk://#diff-688e8374e8eb080cdcdc0f6a36de483e478a26d52bec023cb242b40638d812e2R1-R202) [[2]](diffhunk://#diff-2c9d686962d0246ef611e3d1b303fe8e1018d3c2bf485197b3602bb5ad795d74R1-R156) [[3]](diffhunk://#diff-300709b08a1ef5034ec828b1a7d0c1361178c50d186403d6e12efa7c365e5a34R4-R12) [[4]](diffhunk://#diff-b5e53d6f49da84a364cb91187cacb7db72c188cff77d31d9d1896f6746648ed6R33)
* Updated the ORM prelude and module exports to include `Lazy` and `LazyCollection` for easy access in user code. [[1]](diffhunk://#diff-300709b08a1ef5034ec828b1a7d0c1361178c50d186403d6e12efa7c365e5a34R4-R12) [[2]](diffhunk://#diff-b5e53d6f49da84a364cb91187cacb7db72c188cff77d31d9d1896f6746648ed6R33)

**Query and value handling improvements:**

* Added a `Null` variant to the `Value` enum to represent SQL nulls, updated conversions from `Option<T>` to use `Value::Null`, and ensured proper SQL rendering and query binding for null values. [[1]](diffhunk://#diff-3071a76d669122990dadcfb8d7a5a594c0b4f2cf5e2d2e0581d40f53a373bad1R13) [[2]](diffhunk://#diff-3071a76d669122990dadcfb8d7a5a594c0b4f2cf5e2d2e0581d40f53a373bad1L58-R63) [[3]](diffhunk://#diff-3071a76d669122990dadcfb8d7a5a594c0b4f2cf5e2d2e0581d40f53a373bad1R97) [[4]](diffhunk://#diff-c86195db3f0b0a3d0ce6678751536203b78849cf213ba59dc2c96d222ce1c6bdR20)
* Implemented conversions from `Value` to `i32` and `i64` for easier primary key handling.

**Relation metadata and eager/lazy loading:**

* Refactored `RelationModel` to use a builder pattern (`RelationBuilder`) for safer and clearer construction, and added an `is_eager` flag to indicate if a relation should be eager-loaded by default.
* Modified relation filtering in `Select` queries to respect the `is_eager` flag, ensuring only eager relations are preloaded.

**Macro and code generation updates:**

* Updated code generation utilities to support the new relation and primary key handling, preparing for integration with lazy loading. [[1]](diffhunk://#diff-6febbe7787a80df7fc5935bb4e5f4dc4b90e7aee35b991073f2359454bfd4ff4R1-L9) [[2]](diffhunk://#diff-6febbe7787a80df7fc5935bb4e5f4dc4b90e7aee35b991073f2359454bfd4ff4R30-L31)

These changes lay the groundwork for more efficient and flexible ORM usage, especially in applications with complex or large data models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Introduced lazy-loading capabilities for ORM relations (HasOne, BelongsTo, HasMany) to improve performance by deferring related data fetches until explicitly accessed
* Added full support for null values in query parameters and SQL result processing
* Relation loading behavior can now be configured as eager or lazy based on your application's performance requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->